### PR TITLE
Add test scaffolding and double-click task completion

### DIFF
--- a/frontend/src/components/Board/Board.test.tsx
+++ b/frontend/src/components/Board/Board.test.tsx
@@ -1,11 +1,29 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import Board from '.';
+import type { Task } from '../../types';
 
 describe('Board', () => {
   it('renders categories', () => {
     render(<Board tasks={[]} updateTask={() => {}} completeTask={() => {}} />);
     expect(screen.getByText('Critical')).toBeTruthy();
+  });
+
+  it('completes task on double click', () => {
+    vi.useFakeTimers();
+    const tasks: Task[] = [
+      { id: '1', title: 'Sample', category: 'normal', notes: '', order: 0, done: false }
+    ];
+    const completeTask = vi.fn();
+    const { getByText } = render(
+      <Board tasks={tasks} updateTask={() => {}} completeTask={completeTask} />
+    );
+    const card = getByText('Sample').parentElement as HTMLElement;
+    fireEvent.click(card);
+    fireEvent.click(card, { detail: 2 });
+    vi.runAllTimers();
+    expect(completeTask).toHaveBeenCalledWith('1');
+    vi.useRealTimers();
   });
 });
 

--- a/frontend/src/components/Board/Board.tsx
+++ b/frontend/src/components/Board/Board.tsx
@@ -87,7 +87,13 @@ export default function Board({ tasks, updateTask, completeTask }: Props) {
             ← Back to all categories
           </button>
           <SortableContext items={laneTasks.map((t) => t.id)} strategy={horizontalListSortingStrategy}>
-            <Lane category={expanded} tasks={laneTasks} expanded onTaskClick={setSelected} />
+            <Lane
+              category={expanded}
+              tasks={laneTasks}
+              expanded
+              onTaskClick={setSelected}
+              onTaskComplete={(task) => completeTask(task.id)}
+            />
           </SortableContext>
         </div>
       </DndContext>
@@ -107,11 +113,22 @@ export default function Board({ tasks, updateTask, completeTask }: Props) {
               strategy={horizontalListSortingStrategy}
               key={cat}
             >
-              <Lane category={cat} tasks={laneTasks} onExpand={() => setExpanded(cat)} onTaskClick={setSelected} />
+              <Lane
+                category={cat}
+                tasks={laneTasks}
+                onExpand={() => setExpanded(cat)}
+                onTaskClick={setSelected}
+                onTaskComplete={(task) => completeTask(task.id)}
+              />
             </SortableContext>
           );
         })}
-        <Lane category="done" tasks={tasks.filter((t) => t.done)} onExpand={() => setExpanded('done')} onTaskClick={setSelected} />
+        <Lane
+          category="done"
+          tasks={tasks.filter((t) => t.done)}
+          onExpand={() => setExpanded('done')}
+          onTaskClick={setSelected}
+        />
       </div>
     </DndContext>
   );

--- a/frontend/src/components/Board/Board.tsx
+++ b/frontend/src/components/Board/Board.tsx
@@ -50,15 +50,22 @@ export default function Board({ tasks, updateTask, completeTask }: Props) {
     }
 
     if (fromCat !== toCat) {
-      updateTask(active.id as string, { category: toCat });
+      // move to another lane; place at end if dropped on lane itself
+      const targetLane = tasks.filter((t) => t.category === toCat && !t.done);
+      const newIndex = targetLane.findIndex((t) => t.id === over.id);
+      const order = newIndex === -1 ? targetLane.length : newIndex;
+      updateTask(active.id as string, { category: toCat, order });
       return;
     }
 
     // reorder within lane
     const laneTasks = tasks.filter((t) => t.category === fromCat && !t.done);
     const oldIndex = laneTasks.findIndex((t) => t.id === active.id);
-    const newIndex = laneTasks.findIndex((t) => t.id === over.id);
-    if (oldIndex === newIndex || newIndex === -1) {
+    let newIndex = laneTasks.findIndex((t) => t.id === over.id);
+    if (newIndex === -1) {
+      newIndex = laneTasks.length - 1;
+    }
+    if (oldIndex === newIndex) {
       return;
     }
 

--- a/frontend/src/components/Lane/Lane.tsx
+++ b/frontend/src/components/Lane/Lane.tsx
@@ -10,9 +10,10 @@ interface Props {
   onExpand?: () => void;
   expanded?: boolean;
   onTaskClick?: (task: Task) => void;
+  onTaskComplete?: (task: Task) => void;
 }
 
-export default function Lane({ category, tasks, onExpand, expanded, onTaskClick }: Props) {
+export default function Lane({ category, tasks, onExpand, expanded, onTaskClick, onTaskComplete }: Props) {
   const { setNodeRef, isOver } = useDroppable({ id: category, data: { category } });
   const { isMobile, isLarge } = useLayout();
   const titleMap = {
@@ -52,7 +53,12 @@ export default function Lane({ category, tasks, onExpand, expanded, onTaskClick 
         className={`flex flex-1 flex-wrap transition-colors ${expanded ? 'overflow-auto' : 'overflow-hidden'} ${isMobile ? 'gap-1 px-1 pb-2 pt-2' : 'gap-2 px-2 pb-4 pt-4'}`}
       >
         {visibleTasks.map((task) => (
-          <TaskCard key={task.id} task={task} onClick={() => onTaskClick?.(task)} />
+          <TaskCard
+            key={task.id}
+            task={task}
+            onClick={() => onTaskClick?.(task)}
+            onDoubleClick={() => onTaskComplete?.(task)}
+          />
         ))}
         {extra > 0 && (
           <button

--- a/frontend/src/components/TaskCard/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.test.tsx
@@ -1,13 +1,54 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import TaskCard from '.';
 import type { Task } from '../../types';
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: null
+  })
+}));
 
 describe('TaskCard', () => {
   it('renders task title', () => {
     const task: Task = { id: '1', title: 'Sample', category: 'normal', notes: '', order: 0, done: false };
     render(<TaskCard task={task} />);
     expect(screen.getByText('Sample')).toBeTruthy();
+  });
+
+  it('fires onClick on a single click', () => {
+    vi.useFakeTimers();
+    const task: Task = { id: '1', title: 'Sample', category: 'normal', notes: '', order: 0, done: false };
+    const handleClick = vi.fn();
+    const handleDouble = vi.fn();
+    const { container } = render(<TaskCard task={task} onClick={handleClick} onDoubleClick={handleDouble} />);
+    const card = container.firstElementChild as HTMLElement;
+    fireEvent.click(card, { detail: 1 });
+    expect(handleClick).not.toHaveBeenCalled();
+    expect(handleDouble).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(251);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleDouble).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('fires onDoubleClick on rapid double click', () => {
+    vi.useFakeTimers();
+    const task: Task = { id: '1', title: 'Sample', category: 'normal', notes: '', order: 0, done: false };
+    const handleClick = vi.fn();
+    const handleDouble = vi.fn();
+    const { container } = render(<TaskCard task={task} onClick={handleClick} onDoubleClick={handleDouble} />);
+    const card = container.firstElementChild as HTMLElement;
+    fireEvent.click(card);
+    fireEvent.click(card, { detail: 2 });
+    vi.runAllTimers();
+    expect(handleDouble).toHaveBeenCalledTimes(1);
+    expect(handleClick).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });
 

--- a/frontend/src/components/TaskCard/TaskCard.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.tsx
@@ -1,5 +1,6 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useRef } from 'react';
 import type { Task } from '../../types';
 import { palette } from '../../palette';
 import { useLayout } from '../../context/LayoutContext';
@@ -7,9 +8,10 @@ import { useLayout } from '../../context/LayoutContext';
 interface Props {
   task: Task;
   onClick?: () => void;
+  onDoubleClick?: () => void;
 }
 
-export default function TaskCard({ task, onClick }: Props) {
+export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
   const {
     attributes,
     listeners,
@@ -37,13 +39,29 @@ export default function TaskCard({ task, onClick }: Props) {
     overflow: 'hidden'
   };
 
+  const clickTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  function handlePress() {
+    if (clickTimeout.current) {
+      clearTimeout(clickTimeout.current);
+      clickTimeout.current = null;
+      onDoubleClick?.();
+    } else {
+      clickTimeout.current = setTimeout(() => {
+        clickTimeout.current = null;
+        onClick?.();
+      }, 200);
+    }
+  }
+
   return (
     <div
       ref={setNodeRef}
       style={style}
       {...listeners}
       {...attributes}
-      onClick={onClick}
+      onClick={handlePress}
+      onTouchEnd={handlePress}
       className={`relative select-none rounded-lg border-l-4 bg-white text-gray-800 shadow transition-shadow touch-none hover:shadow-md cursor-pointer ${isMobile ? 'min-w-[60px] px-1 py-1 text-xs' : 'min-w-[160px] px-4 py-3 text-sm'}`}
     >
       <div className="font-medium">{task.title}</div>

--- a/frontend/src/components/TaskCard/TaskCard.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.tsx
@@ -39,18 +39,19 @@ export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
     overflow: 'hidden'
   };
 
-  const clickTimeout = useRef<NodeJS.Timeout | null>(null);
+  const touchTimeout = useRef<NodeJS.Timeout | null>(null);
 
-  function handlePress() {
-    if (clickTimeout.current) {
-      clearTimeout(clickTimeout.current);
-      clickTimeout.current = null;
+  function handleTouchEnd(ev: React.TouchEvent) {
+    ev.preventDefault();
+    if (touchTimeout.current) {
+      clearTimeout(touchTimeout.current);
+      touchTimeout.current = null;
       onDoubleClick?.();
     } else {
-      clickTimeout.current = setTimeout(() => {
-        clickTimeout.current = null;
+      touchTimeout.current = setTimeout(() => {
+        touchTimeout.current = null;
         onClick?.();
-      }, 200);
+      }, 250);
     }
   }
 
@@ -60,8 +61,9 @@ export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
       style={style}
       {...listeners}
       {...attributes}
-      onClick={handlePress}
-      onTouchEnd={handlePress}
+      onClick={!isMobile ? onClick : undefined}
+      onDoubleClick={!isMobile ? onDoubleClick : undefined}
+      onTouchEnd={isMobile ? handleTouchEnd : undefined}
       className={`relative select-none rounded-lg border-l-4 bg-white text-gray-800 shadow transition-shadow touch-none hover:shadow-md cursor-pointer ${isMobile ? 'min-w-[60px] px-1 py-1 text-xs' : 'min-w-[160px] px-4 py-3 text-sm'}`}
     >
       <div className="font-medium">{task.title}</div>

--- a/frontend/src/components/TaskCard/TaskCard.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.tsx
@@ -39,17 +39,21 @@ export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
     overflow: 'hidden'
   };
 
-  const touchTimeout = useRef<NodeJS.Timeout | null>(null);
+  const clickTimeout = useRef<NodeJS.Timeout | null>(null);
 
-  function handleTouchEnd(ev: React.TouchEvent) {
-    ev.preventDefault();
-    if (touchTimeout.current) {
-      clearTimeout(touchTimeout.current);
-      touchTimeout.current = null;
+  function handleClick(ev: React.MouseEvent<HTMLDivElement>) {
+    if (ev.detail === 2) {
+      if (clickTimeout.current) {
+        clearTimeout(clickTimeout.current);
+        clickTimeout.current = null;
+      }
       onDoubleClick?.();
-    } else {
-      touchTimeout.current = setTimeout(() => {
-        touchTimeout.current = null;
+    } else if (ev.detail === 1) {
+      if (clickTimeout.current) {
+        clearTimeout(clickTimeout.current);
+      }
+      clickTimeout.current = setTimeout(() => {
+        clickTimeout.current = null;
         onClick?.();
       }, 250);
     }
@@ -61,9 +65,7 @@ export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
       style={style}
       {...listeners}
       {...attributes}
-      onClick={!isMobile ? onClick : undefined}
-      onDoubleClick={!isMobile ? onDoubleClick : undefined}
-      onTouchEnd={isMobile ? handleTouchEnd : undefined}
+      onClick={handleClick}
       className={`relative select-none rounded-lg border-l-4 bg-white text-gray-800 shadow transition-shadow touch-none hover:shadow-md cursor-pointer ${isMobile ? 'min-w-[60px] px-1 py-1 text-xs' : 'min-w-[160px] px-4 py-3 text-sm'}`}
     >
       <div className="font-medium">{task.title}</div>

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+# Tests
+
+This directory houses the primary test suites for the project.
+
+- `integration/` – scenarios that cover end-to-end interactions across services.
+- `performance/` – load and stress tests to ensure the system performs under pressure.
+
+Add test cases in the respective folders as the application evolves.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,9 @@
+# Integration Tests
+
+These tests ensure that individual services and components work together as expected.
+
+Suggested scenarios:
+
+- Create a task via the API and verify it appears on the board.
+- Drag a task between categories and confirm its category persists after a page reload.
+- Double-click a task card and check that it is marked as done across the system.

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,9 @@
+# Performance Tests
+
+These tests measure how the system behaves under heavy load and prolonged usage.
+
+Suggested scenarios:
+
+- Populate the board with hundreds of tasks and monitor rendering time.
+- Simulate rapid drag-and-drop operations to ensure smooth interaction.
+- Stress test the task API with concurrent create and update operations.


### PR DESCRIPTION
## Summary
- set up top-level `tests` directory with integration and performance test placeholders
- allow task cards to be completed via double-click or double-tap
- plumb completion handler through Lane and Board components

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a2db227228833397d04936785085d6