### PR TITLE
feat: add redis pubsub to stream service

### DIFF
--- a/docs/es_design.md
+++ b/docs/es_design.md
@@ -32,6 +32,7 @@ flowchart LR
     ES[(Event Store – Table Storage)]
     DEQ[[Domain Events Queue]]
     RM[(Read-Model Store)]
+    RS[(Redis)]
   end
 
   %% ─── Flows ─────────────────────
@@ -42,6 +43,8 @@ flowchart LR
   SS -->|Stream Updates| MFE
   SS -->|Stream Updates| WFE
   SS -->|Query| RM
+  RMU -->|Publish Update| RS
+  RS -->|Notify| SS
   API -->|Send Query| RM
   API -->|Send Command| CQ
   CQ -->|Consume Command| DS

--- a/docs/event_flow.md
+++ b/docs/event_flow.md
@@ -26,8 +26,10 @@ flowchart LR
     DS[Domain Service] -->|Publish Domain Event| DEQ[Domain Events Queue]
     DEQ --> RMU[Read-Model Updater]
     RMU --> RM[(Read Model Store)]
+    RMU -->|Publish Update| REDIS[(Redis Pub/Sub)]
+    REDIS --> SS[Stream Service]
     RM --> API
-    RM --> SS[Stream Service]
+    RM --> SS
     SS --> UI
     API --> UI
 ```

--- a/stream-service/api/handlers.go
+++ b/stream-service/api/handlers.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
 
 	"stream-service/domain"
 )
@@ -19,12 +21,82 @@ type Authenticator interface {
 	UserIDFromAuthHeader(string) (string, error)
 }
 
+var (
+	clients   = map[string]map[chan []byte]struct{}{}
+	clientsMu sync.RWMutex
+)
+
 // Register wires up stream endpoints on the given Echo instance.
-func Register(e *echo.Echo, store Storage, auth Authenticator) {
-	e.GET("/stream", streamTasks(store, auth))
+func Register(e *echo.Echo, store Storage, rc *redis.Client, auth Authenticator) {
+	go subscribeUpdates(e.Logger, rc, store)
+	e.GET("/stream", streamTasks(store, rc, auth))
 }
 
-func streamTasks(store Storage, auth Authenticator) echo.HandlerFunc {
+func addClient(userID string, ch chan []byte) {
+	clientsMu.Lock()
+	defer clientsMu.Unlock()
+	if clients[userID] == nil {
+		clients[userID] = make(map[chan []byte]struct{})
+	}
+	clients[userID][ch] = struct{}{}
+}
+
+func removeClient(userID string, ch chan []byte) {
+	clientsMu.Lock()
+	defer clientsMu.Unlock()
+	if m, ok := clients[userID]; ok {
+		delete(m, ch)
+		if len(m) == 0 {
+			delete(clients, userID)
+		}
+	}
+}
+
+func broadcast(userID string, msg []byte) {
+	clientsMu.RLock()
+	defer clientsMu.RUnlock()
+	for ch := range clients[userID] {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}
+
+func subscribeUpdates(logger echo.Logger, rc *redis.Client, store Storage) {
+	ctx := context.Background()
+	for {
+		sub := rc.Subscribe(ctx, "readmodel-updates")
+		ch := sub.Channel()
+		for msg := range ch {
+			var ev struct {
+				UserID string `json:"UserId"`
+			}
+			if err := json.Unmarshal([]byte(msg.Payload), &ev); err != nil {
+				logger.Errorf("unable to parse update: %v", err)
+				continue
+			}
+			tasks, err := store.FetchTasks(ctx, ev.UserID)
+			if err != nil {
+				logger.Errorf("fetch tasks: %v", err)
+				continue
+			}
+			data, err := json.Marshal(tasks)
+			if err != nil {
+				logger.Errorf("marshal tasks: %v", err)
+				continue
+			}
+			if err := rc.Set(ctx, "tasks:"+ev.UserID, data, 0).Err(); err != nil {
+				logger.Errorf("cache tasks: %v", err)
+			}
+			broadcast(ev.UserID, data)
+		}
+		logger.Error("pubsub channel closed, reconnecting")
+		time.Sleep(time.Second)
+	}
+}
+
+func streamTasks(store Storage, rc *redis.Client, auth Authenticator) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		token := c.QueryParam("token")
 		authHeader := c.Request().Header.Get(echo.HeaderAuthorization)
@@ -44,37 +116,59 @@ func streamTasks(store Storage, auth Authenticator) echo.HandlerFunc {
 			return c.String(http.StatusInternalServerError, "stream unsupported")
 		}
 		ctx := c.Request().Context()
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-		for {
+		key := "tasks:" + userID
+		data, err := rc.Get(ctx, key).Bytes()
+		if err != nil {
 			tasks, err := store.FetchTasks(ctx, userID)
 			if err != nil {
 				c.Logger().Error(err)
 				return err
 			}
-			data, err := json.Marshal(tasks)
+			data, err = json.Marshal(tasks)
 			if err != nil {
 				c.Logger().Error(err)
 				return err
 			}
-			if _, err := c.Response().Write([]byte("data: ")); err != nil {
+			if err := rc.Set(ctx, key, data, 0).Err(); err != nil {
 				c.Logger().Error(err)
-				return err
 			}
-			if _, err := c.Response().Write(data); err != nil {
-				c.Logger().Error(err)
-				return err
-			}
-			if _, err := c.Response().Write([]byte("\n\n")); err != nil {
-				c.Logger().Error(err)
-				return err
-			}
-			flusher.Flush()
+		}
+		if _, err := c.Response().Write([]byte("data: ")); err != nil {
+			c.Logger().Error(err)
+			return err
+		}
+		if _, err := c.Response().Write(data); err != nil {
+			c.Logger().Error(err)
+			return err
+		}
+		if _, err := c.Response().Write([]byte("\n\n")); err != nil {
+			c.Logger().Error(err)
+			return err
+		}
+		flusher.Flush()
+
+		ch := make(chan []byte, 1)
+		addClient(userID, ch)
+		defer removeClient(userID, ch)
+
+		for {
 			select {
 			case <-ctx.Done():
 				return nil
-			case <-ticker.C:
-				continue
+			case msg := <-ch:
+				if _, err := c.Response().Write([]byte("data: ")); err != nil {
+					c.Logger().Error(err)
+					return err
+				}
+				if _, err := c.Response().Write(msg); err != nil {
+					c.Logger().Error(err)
+					return err
+				}
+				if _, err := c.Response().Write([]byte("\n\n")); err != nil {
+					c.Logger().Error(err)
+					return err
+				}
+				flusher.Flush()
 			}
 		}
 	}

--- a/stream-service/go.mod
+++ b/stream-service/go.mod
@@ -15,10 +15,13 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/redis/go-redis/v9 v9.12.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.39.0 // indirect

--- a/stream-service/go.sum
+++ b/stream-service/go.sum
@@ -10,9 +10,13 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJ
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -37,6 +41,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
+github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/stream-service/main.go
+++ b/stream-service/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 
 	"stream-service/api"
@@ -28,6 +31,31 @@ func main() {
 		log.Fatalf("storage: %v", err)
 	}
 
+	redisConn := os.Getenv("REDIS_CONNECTION_STRING")
+	if redisConn == "" {
+		log.Fatal("missing redis config")
+	}
+	redisOpts, err := redis.ParseURL(redisConn)
+	if err != nil {
+		parts := strings.Split(redisConn, ",")
+		redisOpts = &redis.Options{Addr: parts[0]}
+		for _, p := range parts[1:] {
+			kv := strings.SplitN(p, "=", 2)
+			if len(kv) != 2 {
+				continue
+			}
+			switch strings.ToLower(kv[0]) {
+			case "password":
+				redisOpts.Password = kv[1]
+			case "ssl":
+				if strings.ToLower(kv[1]) == "true" {
+					redisOpts.TLSConfig = &tls.Config{}
+				}
+			}
+		}
+	}
+	rc := redis.NewClient(redisOpts)
+
 	jwtAudience := os.Getenv("AUTH0_AUDIENCE")
 	domain := os.Getenv("AUTH0_DOMAIN")
 	if jwtAudience == "" || domain == "" {
@@ -46,7 +74,7 @@ func main() {
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},
 	}))
 
-	api.Register(e, store, auth)
+	api.Register(e, store, rc, auth)
 
 	listenAddr := ":9000"
 	if val, ok := os.LookupEnv("STREAM_SERVICE_PORT"); ok {


### PR DESCRIPTION
## Summary
- connect stream service to Redis for task updates
- broadcast read model changes via Redis pub/sub
- document Redis-based streaming in system diagrams

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a4a8081658833387a1206a4d1c8262