### PR TITLE
refactor: extract subscription logic and add tests

### DIFF
--- a/stream-service/api/handlers_test.go
+++ b/stream-service/api/handlers_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
+
+	"stream-service/domain"
+	"stream-service/internal/consts"
+)
+
+type fakeStore struct {
+	tasks  []domain.Task
+	called int
+}
+
+func (f *fakeStore) FetchTasks(ctx context.Context, userID string) ([]domain.Task, error) {
+	f.called++
+	return f.tasks, nil
+}
+
+type fakeAuth struct{}
+
+func (fakeAuth) UserIDFromAuthHeader(string) (string, error) { return "user1", nil }
+
+type flushRecorder struct{ *httptest.ResponseRecorder }
+
+func (flushRecorder) Flush() {}
+
+func setupRedis(t *testing.T) (*redis.Client, func()) {
+	m, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("start miniredis: %v", err)
+	}
+	rc := redis.NewClient(&redis.Options{Addr: m.Addr()})
+	return rc, func() {
+		rc.Close()
+		m.Close()
+	}
+}
+
+func TestAddRemoveClientBroadcast(t *testing.T) {
+	clients = map[string]map[chan []byte]struct{}{}
+	ch := make(chan []byte, 1)
+	addClient("user1", ch)
+	broadcast("user1", []byte("hello"))
+	select {
+	case msg := <-ch:
+		if string(msg) != "hello" {
+			t.Fatalf("expected hello got %s", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no message received")
+	}
+	removeClient("user1", ch)
+	broadcast("user1", []byte("world"))
+	select {
+	case <-ch:
+		t.Fatal("received message after removal")
+	default:
+	}
+}
+
+func TestStreamTasksFetchesFromStoreAndCaches(t *testing.T) {
+	rc, cleanup := setupRedis(t)
+	defer cleanup()
+	store := &fakeStore{tasks: []domain.Task{{ID: "1", Title: "t"}}}
+	auth := fakeAuth{}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/stream", nil)
+	rec := flushRecorder{httptest.NewRecorder()}
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+	c := e.NewContext(req, rec)
+	handler := streamTasks(store, rc, auth)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- handler(c) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	expectedData, _ := json.Marshal(store.tasks)
+	expected := consts.SSEDataPrefix + string(expectedData) + "\n\n"
+	if rec.Body.String() != expected {
+		t.Fatalf("unexpected body %q", rec.Body.String())
+	}
+	if store.called != 1 {
+		t.Fatalf("expected FetchTasks once, got %d", store.called)
+	}
+	if val := rc.Get(context.Background(), consts.TasksKeyPrefix+"user1").Val(); val != string(expectedData) {
+		t.Fatalf("expected cache %s, got %s", string(expectedData), val)
+	}
+}
+
+func TestStreamTasksUsesCache(t *testing.T) {
+	rc, cleanup := setupRedis(t)
+	defer cleanup()
+	tasks := []domain.Task{{ID: "1", Title: "cached"}}
+	data, _ := json.Marshal(tasks)
+	if err := rc.Set(context.Background(), consts.TasksKeyPrefix+"user1", data, 0).Err(); err != nil {
+		t.Fatalf("set cache: %v", err)
+	}
+	store := &fakeStore{tasks: tasks}
+	auth := fakeAuth{}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/stream", nil)
+	rec := flushRecorder{httptest.NewRecorder()}
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+	c := e.NewContext(req, rec)
+	handler := streamTasks(store, rc, auth)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- handler(c) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	expected := consts.SSEDataPrefix + string(data) + "\n\n"
+	if rec.Body.String() != expected {
+		t.Fatalf("unexpected body %q", rec.Body.String())
+	}
+	if store.called != 0 {
+		t.Fatalf("expected no store calls, got %d", store.called)
+	}
+}

--- a/stream-service/go.mod
+++ b/stream-service/go.mod
@@ -7,8 +7,10 @@ toolchain go1.24.3
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.4.0
 	github.com/MicahParks/keyfunc v1.9.0
+	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/labstack/echo/v4 v4.11.4
+	github.com/redis/go-redis/v9 v9.12.1
 	github.com/sirupsen/logrus v1.9.3
 )
 
@@ -21,9 +23,9 @@ require (
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/redis/go-redis/v9 v9.12.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect

--- a/stream-service/go.sum
+++ b/stream-service/go.sum
@@ -10,6 +10,12 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJ
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -53,6 +59,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
 golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=

--- a/stream-service/internal/consts/consts.go
+++ b/stream-service/internal/consts/consts.go
@@ -1,0 +1,6 @@
+package consts
+
+const (
+	TasksKeyPrefix = "tasks:"
+	SSEDataPrefix  = "data: "
+)

--- a/stream-service/subscription/subscription.go
+++ b/stream-service/subscription/subscription.go
@@ -1,0 +1,69 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
+
+	"stream-service/domain"
+	"stream-service/internal/consts"
+)
+
+// Storage fetches tasks for a user.
+type Storage interface {
+	FetchTasks(ctx context.Context, userID string) ([]domain.Task, error)
+}
+
+// SubscribeUpdates listens for read model updates and broadcasts tasks to clients.
+func SubscribeUpdates(
+	ctx context.Context,
+	logger echo.Logger,
+	rc *redis.Client,
+	store Storage,
+	readModelUpdatesChannel string,
+	broadcast func(userID string, data []byte),
+) {
+	for {
+		sub := rc.Subscribe(ctx, readModelUpdatesChannel)
+		ch := sub.Channel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					break
+				}
+				var ev struct {
+					UserID string `json:"UserId"`
+				}
+				if err := json.Unmarshal([]byte(msg.Payload), &ev); err != nil {
+					logger.Errorf("unable to parse update: %v", err)
+					continue
+				}
+				tasks, err := store.FetchTasks(ctx, ev.UserID)
+				if err != nil {
+					logger.Errorf("fetch tasks: %v", err)
+					continue
+				}
+				data, err := json.Marshal(tasks)
+				if err != nil {
+					logger.Errorf("marshal tasks: %v", err)
+					continue
+				}
+				if err := rc.Set(ctx, consts.TasksKeyPrefix+ev.UserID, data, 0).Err(); err != nil {
+					logger.Errorf("cache tasks: %v", err)
+				}
+				broadcast(ev.UserID, data)
+			}
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		logger.Error("pubsub channel closed, reconnecting")
+		time.Sleep(time.Second)
+	}
+}

--- a/stream-service/subscription/subscription_test.go
+++ b/stream-service/subscription/subscription_test.go
@@ -1,0 +1,82 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
+
+	"stream-service/domain"
+	"stream-service/internal/consts"
+)
+
+type fakeStore struct {
+	tasks  []domain.Task
+	called int
+}
+
+func (f *fakeStore) FetchTasks(ctx context.Context, userID string) ([]domain.Task, error) {
+	f.called++
+	return f.tasks, nil
+}
+
+func TestSubscribeUpdates(t *testing.T) {
+	m, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("start miniredis: %v", err)
+	}
+	defer m.Close()
+	rc := redis.NewClient(&redis.Options{Addr: m.Addr()})
+	defer rc.Close()
+	store := &fakeStore{tasks: []domain.Task{{ID: "1", Title: "t"}}}
+	var mu sync.Mutex
+	var gotUID string
+	var gotData []byte
+	broadcast := func(uid string, data []byte) {
+		mu.Lock()
+		gotUID = uid
+		gotData = data
+		mu.Unlock()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		SubscribeUpdates(ctx, echo.New().Logger, rc, store, "chan", broadcast)
+		close(done)
+	}()
+	// wait for subscription to start
+	time.Sleep(50 * time.Millisecond)
+	payload := `{"UserId":"user1"}`
+	if err := rc.Publish(context.Background(), "chan", payload).Err(); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	uid := gotUID
+	data := gotData
+	mu.Unlock()
+	expectedData, _ := json.Marshal(store.tasks)
+	if uid != "user1" {
+		t.Fatalf("expected user1, got %s", uid)
+	}
+	if string(data) != string(expectedData) {
+		t.Fatalf("unexpected data %s", string(data))
+	}
+	if val := rc.Get(context.Background(), consts.TasksKeyPrefix+"user1").Val(); val != string(expectedData) {
+		t.Fatalf("expected cache %s, got %s", string(expectedData), val)
+	}
+	if store.called != 1 {
+		t.Fatalf("expected FetchTasks once, got %d", store.called)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SubscribeUpdates did not exit")
+	}
+}


### PR DESCRIPTION
## Summary
- replace magic strings with shared constants
- move Redis subscription processing into its own module
- add unit tests for streaming handlers and subscription logic

## Testing
- `cd stream-service && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a4cc81b7ec833394d74432aff1cdf7