### PR TITLE
Handle closed Redis pubsub channel in stream-service

### DIFF
--- a/stream-service/domain/subscription.go
+++ b/stream-service/domain/subscription.go
@@ -26,7 +26,8 @@ func SubscribeUpdates(
 			return
 		case msg, ok := <-ch:
 			if !ok {
-				break
+				logger.Error("subscription channel closed")
+				return
 			}
 			var taskEvent TaskEvent
 			if err := json.Unmarshal([]byte(msg.Payload), &taskEvent); err != nil {


### PR DESCRIPTION
## Summary
- stop subscription loop when the Redis PubSub channel closes
- log an error when the channel closes to aid debugging

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_68a78219cb14833398754b72cc3d8d58