### PR TITLE
fix auth token skew and add aria modules

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -24,8 +24,11 @@ vi.mock('@auth0/auth0-react', () => ({
 }));
 
 describe('App', () => {
-  it('applies aria attributes to main and footer', () => {
+  it('applies aria attributes to header, main and footer', () => {
     render(<App />);
+    expect(
+      screen.getByRole('banner', { name: aria.header['aria-label'] })
+    ).toBeTruthy();
     expect(
       screen.getByRole('main', { name: aria.main['aria-label'] })
     ).toBeTruthy();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import App from './App';
+import { aria } from './aria';
+
+vi.mock('./hooks', () => ({
+  useTasks: () => ({
+    tasks: [],
+    addTask: vi.fn(),
+    updateTask: vi.fn(),
+    completeTask: vi.fn()
+  }),
+  useLoginUser: () => {}
+}));
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    loginWithRedirect: vi.fn(),
+    logout: vi.fn(),
+    isAuthenticated: false,
+    user: null,
+    getAccessTokenSilently: vi.fn()
+  })
+}));
+
+describe('App', () => {
+  it('applies aria attributes to main and footer', () => {
+    render(<App />);
+    expect(
+      screen.getByRole('main', { name: aria.main['aria-label'] })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('contentinfo', { name: aria.footer['aria-label'] })
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,7 +63,10 @@ export default function App() {
 
   return (
     <div className="flex min-h-screen flex-col p-2 space-y-2 sm:p-4 sm:space-y-6 lg:space-y-8">
-      <header className="flex items-center justify-between gap-2 sm:gap-4">
+      <header
+        {...aria.header}
+        className="flex items-center justify-between gap-2 sm:gap-4"
+      >
         <UserMenu
           isAuthenticated={isAuthenticated}
           userPicture={user?.picture}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useTasks, useLoginUser } from './hooks';
 import UserMenu from './components/UserMenu';
 import SearchBar from './components/SearchBar';
 import AddTaskButton from './components/AddTaskButton';
+import { aria } from './aria';
 
 export default function App() {
   const { tasks, addTask, updateTask, completeTask } = useTasks();
@@ -73,11 +74,11 @@ export default function App() {
         <AddTaskButton onAdd={handleOpenModal} />
       </header>
 
-      <main className="flex w-full flex-1 overflow-x-auto">
+      <main {...aria.main} className="flex w-full flex-1 overflow-x-auto">
         <Board tasks={filteredTasks} updateTask={updateTask} completeTask={completeTask} />
       </main>
 
-      <footer className="pt-2 text-center text-[10px] text-gray-500 sm:pt-4 sm:text-xs">
+      <footer {...aria.footer} className="pt-2 text-center text-[10px] text-gray-500 sm:pt-4 sm:text-xs">
         Copyright © 2025 Vladimir Pavlov. All rights reserved.
       </footer>
 

--- a/frontend/src/aria.ts
+++ b/frontend/src/aria.ts
@@ -1,0 +1,8 @@
+export const aria = {
+  main: {
+    'aria-label': 'Main content'
+  },
+  footer: {
+    'aria-label': 'Site footer'
+  }
+};

--- a/frontend/src/aria.ts
+++ b/frontend/src/aria.ts
@@ -1,4 +1,7 @@
 export const aria = {
+  header: {
+    'aria-label': 'Site header'
+  },
   main: {
     'aria-label': 'Main content'
   },

--- a/frontend/src/components/AddTaskButton/AddTaskButton.test.tsx
+++ b/frontend/src/components/AddTaskButton/AddTaskButton.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import AddTaskButton from '.';
+import AddTaskButton, { aria } from '.';
 
 describe('AddTaskButton', () => {
   it('calls onAdd when clicked', () => {
     const onAdd = vi.fn();
     render(<AddTaskButton onAdd={onAdd} />);
-    fireEvent.click(screen.getByRole('button', { name: /add task/i }));
+    const button = screen.getByRole('button', { name: aria.button['aria-label'] });
+    fireEvent.click(button);
     expect(onAdd).toHaveBeenCalled();
+    expect(button.getAttribute('aria-label')).toBe(aria.button['aria-label']);
   });
 });

--- a/frontend/src/components/AddTaskButton/AddTaskButton.tsx
+++ b/frontend/src/components/AddTaskButton/AddTaskButton.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { PlusIcon } from '@heroicons/react/24/solid';
+import { aria } from './aria';
 
 interface AddTaskButtonProps {
   onAdd: () => void;
@@ -10,7 +11,7 @@ function AddTaskButton({ onAdd }: AddTaskButtonProps) {
     <div className="flex items-center">
       <button
         onClick={onAdd}
-        aria-label="Add task"
+        {...aria.button}
         className="rounded-full bg-indigo-600 text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 h-8 w-8 p-1 sm:h-10 sm:w-10 sm:p-2"
       >
         <PlusIcon className="h-full w-full" />

--- a/frontend/src/components/AddTaskButton/aria.ts
+++ b/frontend/src/components/AddTaskButton/aria.ts
@@ -1,0 +1,6 @@
+export const aria = {
+  button: {
+    'aria-label': 'Add task'
+  }
+};
+

--- a/frontend/src/components/AddTaskButton/index.tsx
+++ b/frontend/src/components/AddTaskButton/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './AddTaskButton';
+export { aria } from './aria';

--- a/frontend/src/components/Board/Board.test.tsx
+++ b/frontend/src/components/Board/Board.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import Board from '.';
+import Board, { aria } from '.';
 import type { Task } from '../../types';
 
 describe('Board', () => {
   it('renders categories', () => {
     render(<Board tasks={[]} updateTask={() => {}} completeTask={() => {}} />);
+    const board = screen.getByRole('region', { name: aria.root['aria-label'] });
+    expect(board).toBeTruthy();
     expect(screen.getByText('Critical')).toBeTruthy();
   });
 

--- a/frontend/src/components/Board/Board.tsx
+++ b/frontend/src/components/Board/Board.tsx
@@ -11,6 +11,7 @@ import Lane from '../Lane';
 import TaskDetails from '../TaskDetails';
 import type { Category, Task } from '../../types';
 import { useState } from 'react';
+import { aria } from './aria';
 
 interface Props {
   tasks: Task[];
@@ -83,7 +84,7 @@ export default function Board({ tasks, updateTask, completeTask }: Props) {
 
     return (
       <DndContext onDragEnd={handleDragEnd} sensors={sensors}>
-        <div className="mx-auto flex max-w-5xl flex-col">
+        <div {...aria.root} className="mx-auto flex max-w-5xl flex-col">
           <button
             type="button"
             className="mb-4 flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800"
@@ -107,7 +108,7 @@ export default function Board({ tasks, updateTask, completeTask }: Props) {
 
   return (
     <DndContext onDragEnd={handleDragEnd} sensors={sensors}>
-      <div className="flex w-full flex-1 flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-4">
+      <div {...aria.root} className="flex w-full flex-1 flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-4">
         {categories.map((cat) => {
           const laneTasks = tasks
             .filter((t) => t.category === cat && !t.done)

--- a/frontend/src/components/Board/aria.ts
+++ b/frontend/src/components/Board/aria.ts
@@ -1,0 +1,6 @@
+export const aria = {
+  root: {
+    role: 'region',
+    'aria-label': 'Task board'
+  }
+};

--- a/frontend/src/components/Board/index.tsx
+++ b/frontend/src/components/Board/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Board';
+export { aria } from './aria';

--- a/frontend/src/components/Lane/Lane.test.tsx
+++ b/frontend/src/components/Lane/Lane.test.tsx
@@ -1,12 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import Lane from '.';
+import Lane, { aria } from '.';
 import type { Task } from '../../types';
 
 describe('Lane', () => {
   it('shows lane title', () => {
     const tasks: Task[] = [{ id: '1', title: 'Sample', category: 'critical', notes: '', order: 0, done: false }];
     render(<Lane category="critical" tasks={tasks} />);
+    const section = screen.getByRole('region', {
+      name: aria.section('critical')['aria-label']
+    });
+    expect(section).toBeTruthy();
     expect(screen.getByText('Critical')).toBeTruthy();
   });
 });

--- a/frontend/src/components/Lane/Lane.tsx
+++ b/frontend/src/components/Lane/Lane.tsx
@@ -2,6 +2,7 @@ import TaskCard from '../TaskCard';
 import { useDroppable } from '@dnd-kit/core';
 import type { Task, Category } from '../../types';
 import { palette } from '../../palette';
+import { aria } from './aria';
 
 interface Props {
   category: Category | 'done';
@@ -34,7 +35,7 @@ export default function Lane({ category, tasks, onExpand, expanded, onTaskClick,
   const extra = tasks.length - maxVisible;
 
   return (
-    <section className="mb-2 flex w-full flex-col sm:mb-4 sm:flex-1 sm:min-w-[16rem]">
+    <section {...aria.section(category)} className="mb-2 flex w-full flex-col sm:mb-4 sm:flex-1 sm:min-w-[16rem]">
       <h2 className="mx-1 mb-1 sm:mx-2 sm:mb-2">
         <button
           type="button"

--- a/frontend/src/components/Lane/aria.ts
+++ b/frontend/src/components/Lane/aria.ts
@@ -1,0 +1,16 @@
+import type { Category } from '../../types';
+
+const labelMap: Record<Category | 'done', string> = {
+  critical: 'Critical tasks',
+  fun: 'Fun tasks',
+  important: 'Important tasks',
+  normal: 'Normal tasks',
+  done: 'Completed tasks'
+};
+
+export const aria = {
+  section: (cat: Category | 'done') => ({
+    role: 'region',
+    'aria-label': labelMap[cat]
+  })
+};

--- a/frontend/src/components/Lane/index.tsx
+++ b/frontend/src/components/Lane/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Lane';
+export { aria } from './aria';

--- a/frontend/src/components/SearchBar/SearchBar.test.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import SearchBar from '.';
+import SearchBar, { aria } from '.';
 
 describe('SearchBar', () => {
   it('calls onChange with new value', () => {
     const onChange = vi.fn();
     render(<SearchBar value="" onChange={onChange} />);
-    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'abc' } });
+    const input = screen.getByRole('textbox', { name: aria.input['aria-label'] });
+    fireEvent.change(input, { target: { value: 'abc' } });
     expect(onChange).toHaveBeenCalledWith('abc');
+    expect(input.getAttribute('aria-label')).toBe(aria.input['aria-label']);
   });
 });

--- a/frontend/src/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { aria } from './aria';
 
 interface SearchBarProps {
   value: string;
@@ -13,6 +14,7 @@ function SearchBar({ value, onChange }: SearchBarProps) {
         placeholder="Search..."
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        {...aria.input}
         className="w-full rounded-md border border-gray-300 px-1 py-1 text-xs focus:border-indigo-500 focus:ring-indigo-500 sm:px-2 sm:py-1 sm:text-sm"
       />
     </div>

--- a/frontend/src/components/SearchBar/aria.ts
+++ b/frontend/src/components/SearchBar/aria.ts
@@ -1,0 +1,6 @@
+export const aria = {
+  input: {
+    'aria-label': 'Search tasks'
+  }
+};
+

--- a/frontend/src/components/SearchBar/index.tsx
+++ b/frontend/src/components/SearchBar/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './SearchBar';
+export { aria } from './aria';

--- a/frontend/src/components/TaskCard/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import TaskCard from '.';
+import TaskCard, { aria } from '.';
 import type { Task } from '../../types';
 
 vi.mock('@dnd-kit/sortable', () => ({
@@ -17,6 +17,11 @@ describe('TaskCard', () => {
   it('renders task title', () => {
     const task: Task = { id: '1', title: 'Sample', category: 'normal', notes: '', order: 0, done: false };
     render(<TaskCard task={task} />);
+    const card = screen.getByLabelText(aria.root(task.title)['aria-label']);
+    expect(card).toBeTruthy();
+    expect(card.getAttribute('aria-label')).toBe(
+      aria.root(task.title)['aria-label']
+    );
     expect(screen.getByText('Sample')).toBeTruthy();
   });
 

--- a/frontend/src/components/TaskCard/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.test.tsx
@@ -14,13 +14,21 @@ vi.mock('@dnd-kit/sortable', () => ({
 }));
 
 describe('TaskCard', () => {
-  it('renders task title', () => {
+  it('renders task title with button semantics', () => {
     const task: Task = { id: '1', title: 'Sample', category: 'normal', notes: '', order: 0, done: false };
     render(<TaskCard task={task} />);
-    const card = screen.getByLabelText(aria.root(task.title)['aria-label']);
+    const card = screen.getByRole('button', {
+      name: aria.root(task.title)['aria-label']
+    });
     expect(card).toBeTruthy();
     expect(card.getAttribute('aria-label')).toBe(
       aria.root(task.title)['aria-label']
+    );
+    expect(card.getAttribute('aria-roledescription')).toBe(
+      aria.root(task.title)['aria-roledescription']
+    );
+    expect(card.getAttribute('tabindex')).toBe(
+      String(aria.root(task.title).tabIndex)
     );
     expect(screen.getByText('Sample')).toBeTruthy();
   });

--- a/frontend/src/components/TaskCard/TaskCard.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.tsx
@@ -3,6 +3,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useRef } from 'react';
 import type { Task } from '../../types';
 import { palette } from '../../palette';
+import { aria } from './aria';
 
 interface Props {
   task: Task;
@@ -54,6 +55,7 @@ export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
       style={style}
       {...listeners}
       {...attributes}
+      {...aria.root(task.title)}
       onClick={handleClick}
       className="w-full select-none rounded-lg border-l-4 bg-white text-gray-800 shadow transition-shadow touch-none hover:shadow-md cursor-pointer px-1 py-1 text-xs sm:px-4 sm:py-3 sm:text-sm"
     >

--- a/frontend/src/components/TaskCard/aria.ts
+++ b/frontend/src/components/TaskCard/aria.ts
@@ -1,0 +1,5 @@
+export const aria = {
+  root: (title: string) => ({
+    'aria-label': title
+  })
+};

--- a/frontend/src/components/TaskCard/aria.ts
+++ b/frontend/src/components/TaskCard/aria.ts
@@ -1,5 +1,8 @@
 export const aria = {
   root: (title: string) => ({
-    'aria-label': title
+    'aria-label': title,
+    role: 'button',
+    'aria-roledescription': 'Task card',
+    tabIndex: 0
   })
 };

--- a/frontend/src/components/TaskCard/index.tsx
+++ b/frontend/src/components/TaskCard/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './TaskCard';
+export { aria } from './aria';

--- a/frontend/src/components/UserMenu/UserMenu.test.tsx
+++ b/frontend/src/components/UserMenu/UserMenu.test.tsx
@@ -1,17 +1,19 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import UserMenu from '.';
+import UserMenu, { aria } from '.';
 
 describe('UserMenu', () => {
   it('calls onLogin when login icon clicked', () => {
     const onLogin = vi.fn();
     render(<UserMenu isAuthenticated={false} onLogin={onLogin} onLogout={() => {}} />);
-    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+    const btn = screen.getByRole('button', { name: aria.loginButton['aria-label'] });
+    fireEvent.click(btn);
     expect(onLogin).toHaveBeenCalled();
+    expect(btn.getAttribute('aria-label')).toBe(aria.loginButton['aria-label']);
   });
 
   it('renders avatar when authenticated', () => {
     render(<UserMenu isAuthenticated userPicture="pic" onLogin={() => {}} onLogout={() => {}} />);
-    expect(screen.getByAltText('User avatar')).toBeTruthy();
+    expect(screen.getByAltText(aria.avatar.alt)).toBeTruthy();
   });
 });

--- a/frontend/src/components/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/UserMenu/UserMenu.tsx
@@ -1,6 +1,7 @@
 import { Fragment, memo } from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { UserCircleIcon } from '@heroicons/react/24/solid';
+import { aria } from './aria';
 
 interface UserMenuProps {
   isAuthenticated: boolean;
@@ -15,7 +16,7 @@ function UserMenu({ isAuthenticated, userPicture, onLogin, onLogout }: UserMenuP
       {isAuthenticated ? (
         <Menu as="div" className="flex">
           <Menu.Button className="focus:outline-none">
-            <img src={userPicture} alt="User avatar" className="h-10 w-10 rounded-full" />
+            <img src={userPicture} {...aria.avatar} className="h-10 w-10 rounded-full" />
           </Menu.Button>
           <Transition
             as={Fragment}
@@ -41,7 +42,7 @@ function UserMenu({ isAuthenticated, userPicture, onLogin, onLogout }: UserMenuP
           </Transition>
         </Menu>
       ) : (
-        <button onClick={onLogin} aria-label="Log in" className="focus:outline-none">
+        <button onClick={onLogin} {...aria.loginButton} className="focus:outline-none">
           <UserCircleIcon className="h-8 w-8 cursor-pointer text-gray-400 sm:h-10 sm:w-10" />
         </button>
       )}

--- a/frontend/src/components/UserMenu/aria.ts
+++ b/frontend/src/components/UserMenu/aria.ts
@@ -1,0 +1,9 @@
+export const aria = {
+  loginButton: {
+    'aria-label': 'Log in'
+  },
+  avatar: {
+    alt: 'User avatar'
+  }
+};
+

--- a/frontend/src/components/UserMenu/index.tsx
+++ b/frontend/src/components/UserMenu/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './UserMenu';
+export { aria } from './aria';

--- a/prism-api/api/auth.go
+++ b/prism-api/api/auth.go
@@ -36,7 +36,7 @@ func (a *Auth) UserIDFromAuthHeader(h string) (string, error) {
 		return "", errors.New("bad auth header")
 	}
 
-	parser := jwt.NewParser(jwt.WithValidMethods([]string{"RS256"}))
+        parser := jwt.NewParser(jwt.WithValidMethods([]string{"RS256"}), jwt.WithoutClaimsValidation())
 	token, err := parser.Parse(tokenStr, a.JWKS.Keyfunc)
 	if err != nil {
 		return "", err
@@ -47,13 +47,16 @@ func (a *Auth) UserIDFromAuthHeader(h string) (string, error) {
 		return "", errors.New("invalid claims")
 	}
 
-	now := time.Now().Add(time.Minute).Unix()
-	if !claims.VerifyExpiresAt(now, true) {
-		return "", errors.New("token expired")
-	}
-	if !claims.VerifyNotBefore(now, false) {
-		return "", errors.New("token not valid yet")
-	}
+        now := time.Now().Add(time.Minute).Unix()
+        if !claims.VerifyExpiresAt(now, true) {
+                return "", errors.New("token expired")
+        }
+        if !claims.VerifyNotBefore(now, false) {
+                return "", errors.New("token not valid yet")
+        }
+        if !claims.VerifyIssuedAt(now, false) {
+                return "", errors.New("token used before issued")
+        }
 	if !claims.VerifyAudience(a.Audience, false) {
 		return "", errors.New("invalid audience")
 	}


### PR DESCRIPTION
## Summary
- avoid "token used before issued" errors by skipping JWT default claims validation and checking issued-at with clock tolerance
- centralize ARIA attributes for AddTaskButton, SearchBar, and UserMenu
- exercise ARIA modules in unit tests

## Testing
- `go test ./...`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a8449149288333b4806ae4d2461519