### PR TITLE
Adapt integration tests to new command schema

### DIFF
--- a/tests/integration/scenarios/create_edit_complete_task_test.go
+++ b/tests/integration/scenarios/create_edit_complete_task_test.go
@@ -11,20 +11,19 @@ import (
 func TestCreateEditCompleteTask(t *testing.T) {
 	client := newClient(t)
 
-	title := fmt.Sprintf("task-%d", time.Now().UnixNano())
+	taskID := fmt.Sprintf("task-%d", time.Now().UnixNano())
+	title := "task-title-" + taskID
 	// Create task
-	_, err := client.PostJSON("/api/commands", command{Type: "CreateTask", Payload: map[string]interface{}{"title": title}}, nil)
+	_, err := client.PostJSON("/api/commands", []command{{EntityType: "task", EntityID: taskID, Type: "create-task", Data: map[string]interface{}{"title": title}}}, nil)
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
 
-	// Wait for task to appear and capture ID
-	var taskID string
+	// Wait for task to appear
 	pollTasks(t, client, func(ts []task) bool {
 		for _, tk := range ts {
-			if tk.Title == title {
-				taskID = tk.ID
-				return true
+			if tk.ID == taskID {
+				return tk.Title == title
 			}
 		}
 		return false
@@ -32,7 +31,7 @@ func TestCreateEditCompleteTask(t *testing.T) {
 
 	// Edit task title
 	newTitle := title + " updated"
-	_, err = client.PostJSON("/api/commands", command{Type: "EditTask", Payload: map[string]interface{}{"id": taskID, "title": newTitle}}, nil)
+	_, err = client.PostJSON("/api/commands", []command{{EntityType: "task", EntityID: taskID, Type: "update-task", Data: map[string]interface{}{"title": newTitle}}}, nil)
 	if err != nil {
 		t.Fatalf("edit task: %v", err)
 	}
@@ -46,7 +45,7 @@ func TestCreateEditCompleteTask(t *testing.T) {
 	})
 
 	// Complete task
-	_, err = client.PostJSON("/api/commands", command{Type: "CompleteTask", Payload: map[string]interface{}{"id": taskID}}, nil)
+	_, err = client.PostJSON("/api/commands", []command{{EntityType: "task", EntityID: taskID, Type: "complete-task"}}, nil)
 	if err != nil {
 		t.Fatalf("complete task: %v", err)
 	}

--- a/tests/integration/scenarios/create_edit_complete_task_test.go
+++ b/tests/integration/scenarios/create_edit_complete_task_test.go
@@ -49,22 +49,22 @@ func TestCreateEditCompleteTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("complete task: %v", err)
 	}
-	tasks := pollTasks(t, client, func(ts []task) bool {
-		for _, tk := range ts {
-			if tk.ID == taskID {
-				return tk.Status == "Completed" && tk.Title == newTitle
-			}
-		}
-		return false
-	})
+        tasks := pollTasks(t, client, func(ts []task) bool {
+                for _, tk := range ts {
+                        if tk.ID == taskID {
+                                return tk.Done && tk.Title == newTitle
+                        }
+                }
+                return false
+        })
 
-	var final task
-	for _, tk := range tasks {
-		if tk.ID == taskID {
-			final = tk
-			break
-		}
-	}
-	assertx.Equal(t, newTitle, final.Title)
-	assertx.Equal(t, "Completed", final.Status)
+        var final task
+        for _, tk := range tasks {
+                if tk.ID == taskID {
+                        final = tk
+                        break
+                }
+        }
+        assertx.Equal(t, newTitle, final.Title)
+        assertx.Equal(t, true, final.Done)
 }

--- a/tests/integration/scenarios/helpers_test.go
+++ b/tests/integration/scenarios/helpers_test.go
@@ -21,9 +21,9 @@ type command struct {
 }
 
 type task struct {
-	ID     string `json:"id"`
-	Title  string `json:"title"`
-	Status string `json:"status"`
+        ID    string `json:"id"`
+        Title string `json:"title"`
+        Done  bool   `json:"done"`
 }
 
 func newClient(t *testing.T) *httpclient.Client {

--- a/tests/integration/scenarios/helpers_test.go
+++ b/tests/integration/scenarios/helpers_test.go
@@ -13,8 +13,11 @@ import (
 )
 
 type command struct {
-	Type    string                 `json:"type"`
-	Payload map[string]interface{} `json:"payload"`
+	ID         string                 `json:"id,omitempty"`
+	EntityID   string                 `json:"entityId,omitempty"`
+	EntityType string                 `json:"entityType"`
+	Type       string                 `json:"type"`
+	Data       map[string]interface{} `json:"data,omitempty"`
 }
 
 type task struct {

--- a/tests/integration/scenarios/streaming_live_updates_test.go
+++ b/tests/integration/scenarios/streaming_live_updates_test.go
@@ -13,16 +13,15 @@ func TestStreamingLiveUpdates(t *testing.T) {
 	client := newClient(t)
 
 	// Create a task to mutate
-	title := fmt.Sprintf("stream-%d", time.Now().UnixNano())
-	if _, err := client.PostJSON("/api/commands", command{Type: "CreateTask", Payload: map[string]interface{}{"title": title}}, nil); err != nil {
+	taskID := fmt.Sprintf("stream-%d", time.Now().UnixNano())
+	title := "stream-title-" + taskID
+	if _, err := client.PostJSON("/api/commands", []command{{EntityType: "task", EntityID: taskID, Type: "create-task", Data: map[string]interface{}{"title": title}}}, nil); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	var taskID string
 	pollTasks(t, client, func(ts []task) bool {
 		for _, tk := range ts {
-			if tk.Title == title {
-				taskID = tk.ID
-				return true
+			if tk.ID == taskID {
+				return tk.Title == title
 			}
 		}
 		return false
@@ -61,7 +60,7 @@ func TestStreamingLiveUpdates(t *testing.T) {
 
 	// mutate the task
 	newTitle := title + "-sse"
-	if _, err := client.PostJSON("/api/commands", command{Type: "EditTask", Payload: map[string]interface{}{"id": taskID, "title": newTitle}}, nil); err != nil {
+	if _, err := client.PostJSON("/api/commands", []command{{EntityType: "task", EntityID: taskID, Type: "update-task", Data: map[string]interface{}{"title": newTitle}}}, nil); err != nil {
 		t.Fatalf("edit task: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- align integration test commands with new `entityType`/`entityId`/`data` schema
- send commands as arrays and use new `create-task`, `update-task`, `complete-task` types
- relax status checks to accept either 200 or 202 responses

## Testing
- `cd tests/integration && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68af6b8e168083338e26894463891878