### PR TITLE
Improve integration test diagnostics

### DIFF
--- a/tests/integration/scenarios/create_edit_complete_task_test.go
+++ b/tests/integration/scenarios/create_edit_complete_task_test.go
@@ -20,7 +20,7 @@ func TestCreateEditCompleteTask(t *testing.T) {
 	}
 
 	// Wait for task to appear
-	pollTasks(t, client, func(ts []task) bool {
+	pollTasks(t, client, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Title == title
@@ -35,7 +35,7 @@ func TestCreateEditCompleteTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("edit task: %v", err)
 	}
-	pollTasks(t, client, func(ts []task) bool {
+	pollTasks(t, client, fmt.Sprintf("task %s to have updated title %s", taskID, newTitle), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Title == newTitle
@@ -49,7 +49,7 @@ func TestCreateEditCompleteTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("complete task: %v", err)
 	}
-	tasks := pollTasks(t, client, func(ts []task) bool {
+	tasks := pollTasks(t, client, fmt.Sprintf("task %s to be completed with title %s", taskID, newTitle), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Done && tk.Title == newTitle

--- a/tests/integration/scenarios/ordering_and_idempotency_test.go
+++ b/tests/integration/scenarios/ordering_and_idempotency_test.go
@@ -23,7 +23,7 @@ func TestOrderingAndIdempotency(t *testing.T) {
 		t.Fatalf("second create: %v", err)
 	}
 
-	tasks := pollTasks(t, client, func(ts []task) bool {
+	tasks := pollTasks(t, client, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Title == title
@@ -49,7 +49,7 @@ func TestOrderingAndIdempotency(t *testing.T) {
 		}
 	}
 	finalTitle := titles[len(titles)-1]
-	tasks = pollTasks(t, client, func(ts []task) bool {
+	tasks = pollTasks(t, client, fmt.Sprintf("task %s to have final title %s", taskID, finalTitle), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Title == finalTitle

--- a/tests/integration/scenarios/projection_eventual_consistency_test.go
+++ b/tests/integration/scenarios/projection_eventual_consistency_test.go
@@ -22,7 +22,7 @@ func TestProjectionEventualConsistency(t *testing.T) {
 		t.Fatalf("unexpected status %d", resp.StatusCode)
 	}
 
-	pollTasks(t, client, func(ts []task) bool {
+	pollTasks(t, client, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Title == title

--- a/tests/integration/scenarios/resilience_backpressure_test.go
+++ b/tests/integration/scenarios/resilience_backpressure_test.go
@@ -43,7 +43,7 @@ func TestResilienceBackpressure(t *testing.T) {
 		t.Fatalf("restart domain-service: %v", err)
 	}
 	start := time.Now()
-	pollTasks(t, client, func(ts []task) bool {
+	pollTasks(t, client, fmt.Sprintf("task %s to appear with title %s after restart", taskID, title), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Title == title

--- a/tests/integration/scenarios/streaming_live_updates_test.go
+++ b/tests/integration/scenarios/streaming_live_updates_test.go
@@ -18,7 +18,7 @@ func TestStreamingLiveUpdates(t *testing.T) {
 	if _, err := prismApiClient.PostJSON("/api/commands", []command{{EntityType: "task", EntityID: taskID, Type: "create-task", Data: map[string]any{"title": title}}}, nil); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	pollTasks(t, prismApiClient, func(ts []task) bool {
+	pollTasks(t, prismApiClient, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
 		for _, tk := range ts {
 			if tk.ID == taskID {
 				return tk.Title == title


### PR DESCRIPTION
## Summary
- Enhance pollTasks helper to include description and last seen tasks in timeout errors
- Annotate integration tests with descriptive pollTasks conditions

## Testing
- `go test ./scenarios -run TestCreateEditCompleteTask -count=1` *(fails: generate token: TEST_JWT_SECRET must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68b55004cfd48333b8dedeef239ea2b1