### PR TITLE
Run function hosts in integration script

### DIFF
--- a/read-model-updater/domain/entities.go
+++ b/read-model-updater/domain/entities.go
@@ -15,29 +15,29 @@ const (
 // TaskEntity represents a task stored in the read model.
 type TaskEntity struct {
 	Entity
-	Title         string `json:"Title,omitempty"`
-	Notes         string `json:"Notes,omitempty"`
-	Category      string `json:"Category,omitempty"`
-	Order         int    `json:"Order"`
-	OrderType     string `json:"Order@odata.type"`
-	Done          bool   `json:"Done"`
-	DoneType      string `json:"Done@odata.type"`
-	Timestamp     int64  `json:"Timestamp"`
-	TimestampType string `json:"Timestamp@odata.type"`
+	Title              string `json:"Title,omitempty"`
+	Notes              string `json:"Notes,omitempty"`
+	Category           string `json:"Category,omitempty"`
+	Order              int    `json:"Order"`
+	OrderType          string `json:"Order@odata.type"`
+	Done               bool   `json:"Done"`
+	DoneType           string `json:"Done@odata.type"`
+	EventTimestamp     int64  `json:"EventTimestamp,string"`
+	EventTimestampType string `json:"EventTimestamp@odata.type"`
 }
 
 // TaskUpdate carries partial updates for a task.
 type TaskUpdate struct {
 	Entity
-	Title         *string `json:"Title,omitempty"`
-	Notes         *string `json:"Notes,omitempty"`
-	Category      *string `json:"Category,omitempty"`
-	Order         *int    `json:"Order,omitempty"`
-	OrderType     *string `json:"Order@odata.type,omitempty"`
-	Done          *bool   `json:"Done,omitempty"`
-	DoneType      *string `json:"Done@odata.type,omitempty"`
-	Timestamp     *int64  `json:"Timestamp,omitempty"`
-	TimestampType *string `json:"Timestamp@odata.type,omitempty"`
+	Title              *string `json:"Title,omitempty"`
+	Notes              *string `json:"Notes,omitempty"`
+	Category           *string `json:"Category,omitempty"`
+	Order              *int    `json:"Order,omitempty"`
+	OrderType          *string `json:"Order@odata.type,omitempty"`
+	Done               *bool   `json:"Done,omitempty"`
+	DoneType           *string `json:"Done@odata.type,omitempty"`
+	EventTimestamp     *int64  `json:"EventTimestamp,omitempty,string"`
+	EventTimestampType *string `json:"EventTimestamp@odata.type,omitempty"`
 }
 
 // UserEntity represents a user stored in the read model.
@@ -53,8 +53,8 @@ type UserSettingsEntity struct {
 	TasksPerCategoryType string `json:"TasksPerCategory@odata.type"`
 	ShowDoneTasks        bool   `json:"ShowDoneTasks"`
 	ShowDoneTasksType    string `json:"ShowDoneTasks@odata.type"`
-	Timestamp            int64  `json:"Timestamp"`
-	TimestampType        string `json:"Timestamp@odata.type"`
+	EventTimestamp       int64  `json:"EventTimestamp,string"`
+	EventTimestampType   string `json:"EventTimestamp@odata.type"`
 }
 
 type UserSettingsUpdate struct {
@@ -63,6 +63,6 @@ type UserSettingsUpdate struct {
 	TasksPerCategoryType *string `json:"TasksPerCategory@odata.type,omitempty"`
 	ShowDoneTasks        *bool   `json:"ShowDoneTasks,omitempty"`
 	ShowDoneTasksType    *string `json:"ShowDoneTasks@odata.type,omitempty"`
-	Timestamp            *int64  `json:"Timestamp,omitempty"`
-	TimestampType        *string `json:"Timestamp@odata.type,omitempty"`
+	EventTimestamp       *int64  `json:"EventTimestamp,omitempty,string"`
+	EventTimestampType   *string `json:"EventTimestamp@odata.type,omitempty"`
 }

--- a/read-model-updater/storage/storage.go
+++ b/read-model-updater/storage/storage.go
@@ -80,32 +80,32 @@ func (s *Storage) GetTask(ctx context.Context, pk, rk string) (*domain.TaskEntit
 		return nil, err
 	}
 	var raw struct {
-		PartitionKey  string          `json:"PartitionKey"`
-		RowKey        string          `json:"RowKey"`
-		Title         string          `json:"Title,omitempty"`
-		Notes         string          `json:"Notes,omitempty"`
-		Category      string          `json:"Category,omitempty"`
-		Order         int             `json:"Order"`
-		OrderType     string          `json:"Order@odata.type"`
-		Done          bool            `json:"Done"`
-		DoneType      string          `json:"Done@odata.type"`
-		Timestamp     json.RawMessage `json:"Timestamp"`
-		TimestampType string          `json:"Timestamp@odata.type"`
+		PartitionKey       string          `json:"PartitionKey"`
+		RowKey             string          `json:"RowKey"`
+		Title              string          `json:"Title,omitempty"`
+		Notes              string          `json:"Notes,omitempty"`
+		Category           string          `json:"Category,omitempty"`
+		Order              int             `json:"Order"`
+		OrderType          string          `json:"Order@odata.type"`
+		Done               bool            `json:"Done"`
+		DoneType           string          `json:"Done@odata.type"`
+		EventTimestamp     json.RawMessage `json:"EventTimestamp"`
+		EventTimestampType string          `json:"EventTimestamp@odata.type"`
 	}
 	if err := json.Unmarshal(ent.Value, &raw); err != nil {
 		return nil, err
 	}
 	task := domain.TaskEntity{
-		Entity:        domain.Entity{PartitionKey: raw.PartitionKey, RowKey: raw.RowKey},
-		Title:         raw.Title,
-		Notes:         raw.Notes,
-		Category:      raw.Category,
-		Order:         raw.Order,
-		OrderType:     raw.OrderType,
-		Done:          raw.Done,
-		DoneType:      raw.DoneType,
-		Timestamp:     parseTimestamp(raw.Timestamp),
-		TimestampType: raw.TimestampType,
+		Entity:             domain.Entity{PartitionKey: raw.PartitionKey, RowKey: raw.RowKey},
+		Title:              raw.Title,
+		Notes:              raw.Notes,
+		Category:           raw.Category,
+		Order:              raw.Order,
+		OrderType:          raw.OrderType,
+		Done:               raw.Done,
+		DoneType:           raw.DoneType,
+		EventTimestamp:     parseTimestamp(raw.EventTimestamp),
+		EventTimestampType: raw.EventTimestampType,
 	}
 	return &task, nil
 }
@@ -172,8 +172,8 @@ func (s *Storage) GetUserSettings(ctx context.Context, id string) (*domain.UserS
 		TasksPerCategoryTy string          `json:"TasksPerCategory@odata.type"`
 		ShowDoneTasks      bool            `json:"ShowDoneTasks"`
 		ShowDoneTasksType  string          `json:"ShowDoneTasks@odata.type"`
-		Timestamp          json.RawMessage `json:"Timestamp"`
-		TimestampType      string          `json:"Timestamp@odata.type"`
+		EventTimestamp     json.RawMessage `json:"EventTimestamp"`
+		EventTimestampType string          `json:"EventTimestamp@odata.type"`
 	}
 	if err := json.Unmarshal(ent.Value, &raw); err != nil {
 		return nil, err
@@ -184,8 +184,8 @@ func (s *Storage) GetUserSettings(ctx context.Context, id string) (*domain.UserS
 		TasksPerCategoryType: raw.TasksPerCategoryTy,
 		ShowDoneTasks:        raw.ShowDoneTasks,
 		ShowDoneTasksType:    raw.ShowDoneTasksType,
-		Timestamp:            parseTimestamp(raw.Timestamp),
-		TimestampType:        raw.TimestampType,
+		EventTimestamp:       parseTimestamp(raw.EventTimestamp),
+		EventTimestampType:   raw.EventTimestampType,
 	}
 	return &sEnt, nil
 }


### PR DESCRIPTION
## Summary
- start domain service and read model updater using Azure Functions host
- avoid port conflicts by letting Functions Core Tools manage the ports
- serialize event timestamps as strings to ensure read-model events persist

## Testing
- `tests/scripts/run-integration-local.sh` *(fails: Azurite cannot start; module './templates.js' not found)*
- `go test ./read-model-updater/...` *(fails: module requires Go 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_68b731d269248333a1b412de77eba6bf