### PR TITLE
Fix task completion in read model

### DIFF
--- a/read-model-updater/domain/apply.go
+++ b/read-model-updater/domain/apply.go
@@ -171,12 +171,20 @@ func Apply(ctx context.Context, st Storage, ev Event) error {
 			log.Warnf("task %s received event with identical timestamp", rk)
 		}
 		if ev.Timestamp >= ent.EventTimestamp {
-			ent.Done = true
-			ent.DoneType = EdmBoolean
-			ent.EventTimestamp = ev.Timestamp
-			ent.EventTimestampType = EdmInt64
+			done := true
+			dt := EdmBoolean
+			ts := ev.Timestamp
+			tp := EdmInt64
+			upd := TaskUpdate{
+				Entity:             Entity{PartitionKey: pk, RowKey: rk},
+				Done:               &done,
+				DoneType:           &dt,
+				EventTimestamp:     &ts,
+				EventTimestampType: &tp,
+			}
+			return st.UpdateTask(ctx, upd)
 		}
-		return st.UpsertTask(ctx, *ent)
+		return nil
 	case UserCreated:
 		var user UserEventData
 		if err := json.Unmarshal(ev.Data, &user); err != nil {


### PR DESCRIPTION
## Summary
- mark tasks as done using partial update to avoid overwriting fields

## Testing
- `go test ./...` (in read-model-updater)
- `go vet ./...` (in read-model-updater)
- `./tests/scripts/run-integration-local.sh` *(fails: domain-service missing - Service unhealthy - redis is unavailable etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f0de5afc8333a7f8b08c3bd9f162