### PR TITLE
test: stabilize task projection scenarios

### DIFF
--- a/tests/integration/scenarios/stale_update_merge_test.go
+++ b/tests/integration/scenarios/stale_update_merge_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestStaleUpdateMergesFields(t *testing.T) {
-	connStr := os.Getenv("STORAGE_CONNECTION_STRING_LOCAL")
+	connStr := os.Getenv("STORAGE_CONNECTION_STRING")
 	qName := os.Getenv("DOMAIN_EVENTS_QUEUE")
 	queue, err := azqueue.NewQueueClientFromConnectionString(connStr, qName, nil)
 	if err != nil {
@@ -33,12 +33,13 @@ func TestStaleUpdateMergesFields(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
+	base := time.Now().UnixNano()
 	send(map[string]any{
 		"Id":         "1",
 		"EntityId":   taskID,
 		"EntityType": "task",
 		"Type":       "task-created",
-		"Timestamp":  1,
+		"Timestamp":  base,
 		"UserId":     userID,
 		"Data":       map[string]any{"title": "t"},
 	})
@@ -47,7 +48,7 @@ func TestStaleUpdateMergesFields(t *testing.T) {
 		"EntityId":   taskID,
 		"EntityType": "task",
 		"Type":       "task-updated",
-		"Timestamp":  3,
+		"Timestamp":  base + 2,
 		"UserId":     userID,
 		"Data":       map[string]any{"done": true},
 	})
@@ -56,7 +57,7 @@ func TestStaleUpdateMergesFields(t *testing.T) {
 		"EntityId":   taskID,
 		"EntityType": "task",
 		"Type":       "task-updated",
-		"Timestamp":  2,
+		"Timestamp":  base + 1,
 		"UserId":     userID,
 		"Data":       map[string]any{"notes": "note"},
 	})


### PR DESCRIPTION
## Summary
- verify task commands succeed and wait for each update to be reflected before sending the next
- send stale update events with realistic timestamps using the default storage connection string

## Testing
- `cd tests/integration && PRISM_API_BASE=http://localhost:8080 AZ_FUNC_HEALTH_ENDPOINT=/ STORAGE_CONNECTION_STRING="" DOMAIN_EVENTS_QUEUE=domain-events TEST_JWT_SECRET=testsecret go test ./scenarios -run TestOrderingAndIdempotency -count=1 -v` *(fails: API not reachable: dial tcp [::1]:8080: connect: connection refused)*
- `cd tests/integration && PRISM_API_BASE=http://localhost:8080 AZ_FUNC_HEALTH_ENDPOINT=/ STORAGE_CONNECTION_STRING="" DOMAIN_EVENTS_QUEUE=domain-events TEST_JWT_SECRET=testsecret go test ./scenarios -run TestStaleUpdateMergesFields -count=1 -v` *(fails: queue client: connection string is either blank or malformed)*

------
https://chatgpt.com/codex/tasks/task_e_68b870b166648333be59cea7af5652f2