### PR TITLE
refactor: generate entity IDs in domain service

### DIFF
--- a/docs/es_design.md
+++ b/docs/es_design.md
@@ -69,8 +69,8 @@ flowchart LR
 ## Execution Flow
 
 1. **Command path**
-    - Frontend sends an intent (e.g., *AddItemToCart*) → API publishes command to **Command Queue**.
-    - **Domain Service** consumes the command, loads the aggregate’s past events from **Event Store**, executes business logic, then writes new events back to the store.
+    - Frontend sends an intent (e.g., *AddItemToCart*) → API publishes command to **Command Queue** and returns generated idempotency keys to the caller.
+    - **Domain Service** consumes the command, generates entity identifiers for new aggregates, loads any existing events from **Event Store**, executes business logic, then writes new events back to the store.
     - Same service publishes those events to **Domain Events Queue**.
 2. **Read‑side update**
    **Read‑Model Updater** consumes the event stream, materialises projections in **Read‑Model Store**.

--- a/docs/event_flow.md
+++ b/docs/event_flow.md
@@ -16,7 +16,9 @@ sequenceDiagram
     UI->>API: HTTP Command Request
     API->>RS: Record Idempotency Key
     API->>CQ: Enqueue Command
+    API-->>UI: Return Idempotency Key(s)
     CQ->>DS: Deliver Command
+    DS->>DS: Generate Entity ID
     DS->>ES: Append Domain Events
     DS-->>UI: Command Accepted
 ```

--- a/domain-service/src/DomainService.Domain/CommandHandlers/CompleteTask.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/CompleteTask.cs
@@ -15,7 +15,7 @@ internal sealed class CompleteTask(ITaskEventRepository taskRepo, IEventQueue ev
         var state = TaskStateBuilder.From(events);
         if (state.Title == null || state.Done) return Unit.Value;
 
-        var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Completed, null, request.Timestamp, request.UserId);
+        var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Completed, null, request.Timestamp, request.UserId, request.IdempotencyKey);
         await _taskRepo.Add(ev, ct);
         await _eventQueue.Add(ev, ct);
         return Unit.Value;

--- a/domain-service/src/DomainService.Domain/CommandHandlers/CreateTask.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/CreateTask.cs
@@ -11,8 +11,10 @@ internal sealed class CreateTask(ITaskEventRepository taskRepo, IEventQueue even
 
     public async Task<Unit> Handle(CreateTaskCommand request, CancellationToken ct)
     {
+        if (await _taskRepo.Exists(request.IdempotencyKey, ct)) return Unit.Value;
+
         var taskId = Guid.NewGuid().ToString();
-        var ev = new Event(Guid.NewGuid().ToString(), taskId, EntityTypes.Task, TaskEventTypes.Created, request.Data, request.Timestamp, request.UserId);
+        var ev = new Event(Guid.NewGuid().ToString(), taskId, EntityTypes.Task, TaskEventTypes.Created, request.Data, request.Timestamp, request.UserId, request.IdempotencyKey);
         await _taskRepo.Add(ev, ct);
         await _eventQueue.Add(ev, ct);
         return Unit.Value;

--- a/domain-service/src/DomainService.Domain/CommandHandlers/CreateTask.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/CreateTask.cs
@@ -11,11 +11,8 @@ internal sealed class CreateTask(ITaskEventRepository taskRepo, IEventQueue even
 
     public async Task<Unit> Handle(CreateTaskCommand request, CancellationToken ct)
     {
-        var events = await _taskRepo.Get(request.TaskId, ct);
-        var state = TaskStateBuilder.From(events);
-        if (state.Title != null) return Unit.Value;
-
-        var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Created, request.Data, request.Timestamp, request.UserId);
+        var taskId = Guid.NewGuid().ToString();
+        var ev = new Event(Guid.NewGuid().ToString(), taskId, EntityTypes.Task, TaskEventTypes.Created, request.Data, request.Timestamp, request.UserId);
         await _taskRepo.Add(ev, ct);
         await _eventQueue.Add(ev, ct);
         return Unit.Value;

--- a/domain-service/src/DomainService.Domain/CommandHandlers/LoginUser.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/LoginUser.cs
@@ -27,7 +27,8 @@ internal sealed class LoginUser(IUserEventRepository userRepo, IEventQueue event
             type,
             data,
             request.Timestamp,
-            request.UserId);
+            request.UserId,
+            request.IdempotencyKey);
         await _userRepo.Add(ev, ct);
         await _eventQueue.Add(ev, ct);
         if (!exists)
@@ -40,7 +41,8 @@ internal sealed class LoginUser(IUserEventRepository userRepo, IEventQueue event
                 UserEventTypes.SettingsCreated,
                 settingsData,
                 request.Timestamp,
-                request.UserId);
+                request.UserId,
+                request.IdempotencyKey);
             await _userRepo.Add(settingsEv, ct);
             await _eventQueue.Add(settingsEv, ct);
         }

--- a/domain-service/src/DomainService.Domain/CommandHandlers/LogoutUser.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/LogoutUser.cs
@@ -11,7 +11,7 @@ internal sealed class LogoutUser(IUserEventRepository userRepo, IEventQueue even
 
     public async Task<Unit> Handle(LogoutUserCommand request, CancellationToken ct)
     {
-        var ev = new Event(Guid.NewGuid().ToString(), request.UserId, EntityTypes.User, UserEventTypes.Logout, null, request.Timestamp, request.UserId);
+        var ev = new Event(Guid.NewGuid().ToString(), request.UserId, EntityTypes.User, UserEventTypes.Logout, null, request.Timestamp, request.UserId, request.IdempotencyKey);
         await _userRepo.Add(ev, ct);
         await _eventQueue.Add(ev, ct);
         return Unit.Value;

--- a/domain-service/src/DomainService.Domain/CommandHandlers/UpdateTask.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/UpdateTask.cs
@@ -17,7 +17,7 @@ internal sealed class UpdateTask(ITaskEventRepository taskRepo, IEventQueue even
         var state = TaskStateBuilder.From(events);
         if (state.Title == null) return Unit.Value;
 
-        var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Updated, request.Data, request.Timestamp, request.UserId);
+        var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Updated, request.Data, request.Timestamp, request.UserId, request.IdempotencyKey);
         await _taskRepo.Add(ev, ct);
         await _eventQueue.Add(ev, ct);
 
@@ -32,7 +32,8 @@ internal sealed class UpdateTask(ITaskEventRepository taskRepo, IEventQueue even
                 TaskEventTypes.Updated,
                 JsonSerializer.SerializeToElement(new TaskStatusData(false)),
                 request.Timestamp,
-                request.UserId);
+                request.UserId,
+                request.IdempotencyKey);
             await _taskRepo.Add(reopen, ct);
             await _eventQueue.Add(reopen, ct);
         }

--- a/domain-service/src/DomainService.Domain/CommandHandlers/UpdateUserSettings.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/UpdateUserSettings.cs
@@ -18,7 +18,8 @@ internal sealed class UpdateUserSettings(IUserEventRepository userRepo, IEventQu
             UserEventTypes.SettingsUpdated,
             request.Data,
             request.Timestamp,
-            request.UserId);
+            request.UserId,
+            request.IdempotencyKey);
         await _userRepo.Add(ev, ct);
         await _eventQueue.Add(ev, ct);
         return Unit.Value;

--- a/domain-service/src/DomainService.Domain/Commands/CommandFactory.cs
+++ b/domain-service/src/DomainService.Domain/Commands/CommandFactory.cs
@@ -21,16 +21,19 @@ namespace DomainService.Domain.Commands
                         CommandTypes.CreateTask => new CreateTaskCommand(
                             envelope.Command.Data,
                             envelope.UserId,
-                            envelope.Command.Timestamp),
+                            envelope.Command.Timestamp,
+                            envelope.Command.Id),
                         CommandTypes.UpdateTask => new UpdateTaskCommand(
                             envelope.Command.Data?.GetProperty("id").GetString() ?? string.Empty,
                             envelope.Command.Data,
                             envelope.UserId,
-                            envelope.Command.Timestamp),
+                            envelope.Command.Timestamp,
+                            envelope.Command.Id),
                         CommandTypes.CompleteTask => new CompleteTaskCommand(
                             envelope.Command.Data?.GetProperty("id").GetString() ?? string.Empty,
                             envelope.UserId,
-                            envelope.Command.Timestamp),
+                            envelope.Command.Timestamp,
+                            envelope.Command.Id),
                         _ => throw new ArgumentException("Unknown command type!", nameof(queueMessage))
                     },
                     EntityTypes.User => envelope.Command.Type switch
@@ -39,13 +42,14 @@ namespace DomainService.Domain.Commands
                             envelope.UserId,
                             envelope.Command.Data?.GetProperty("name").GetString() ?? string.Empty,
                             envelope.Command.Data?.GetProperty("email").GetString() ?? string.Empty,
-                            envelope.Command.Timestamp),
-                        CommandTypes.LogoutUser => new LogoutUserCommand(envelope.UserId, envelope.Command.Timestamp),
+                            envelope.Command.Timestamp,
+                            envelope.Command.Id),
+                        CommandTypes.LogoutUser => new LogoutUserCommand(envelope.UserId, envelope.Command.Timestamp, envelope.Command.Id),
                         _ => throw new ArgumentException("Unknown Command.Type!", nameof(queueMessage))
                     },
                     EntityTypes.UserSettings => envelope.Command.Type switch
                     {
-                        CommandTypes.UpdateUserSettings => new UpdateUserSettingsCommand(envelope.Command.Data, envelope.UserId, envelope.Command.Timestamp),
+                        CommandTypes.UpdateUserSettings => new UpdateUserSettingsCommand(envelope.Command.Data, envelope.UserId, envelope.Command.Timestamp, envelope.Command.Id),
                         _ => throw new ArgumentException("Unknown Command.Type!", nameof(queueMessage))
                     },
                     _ => throw new ArgumentException("Unknown Command.EntityType!", nameof(queueMessage))

--- a/domain-service/src/DomainService.Domain/Commands/CommandFactory.cs
+++ b/domain-service/src/DomainService.Domain/Commands/CommandFactory.cs
@@ -18,19 +18,29 @@ namespace DomainService.Domain.Commands
                 {
                     EntityTypes.Task => envelope.Command.Type switch
                     {
-                        CommandTypes.CreateTask => new CreateTaskCommand(envelope.Command.EntityId, envelope.Command.Data, envelope.UserId, envelope.Command.Timestamp),
-                        CommandTypes.UpdateTask => new UpdateTaskCommand(envelope.Command.EntityId, envelope.Command.Data, envelope.UserId, envelope.Command.Timestamp),
-                        CommandTypes.CompleteTask => new CompleteTaskCommand(envelope.Command.EntityId, envelope.UserId, envelope.Command.Timestamp),
+                        CommandTypes.CreateTask => new CreateTaskCommand(
+                            envelope.Command.Data,
+                            envelope.UserId,
+                            envelope.Command.Timestamp),
+                        CommandTypes.UpdateTask => new UpdateTaskCommand(
+                            envelope.Command.Data?.GetProperty("id").GetString() ?? string.Empty,
+                            envelope.Command.Data,
+                            envelope.UserId,
+                            envelope.Command.Timestamp),
+                        CommandTypes.CompleteTask => new CompleteTaskCommand(
+                            envelope.Command.Data?.GetProperty("id").GetString() ?? string.Empty,
+                            envelope.UserId,
+                            envelope.Command.Timestamp),
                         _ => throw new ArgumentException("Unknown command type!", nameof(queueMessage))
                     },
                     EntityTypes.User => envelope.Command.Type switch
                     {
                         CommandTypes.LoginUser => new LoginUserCommand(
-                            envelope.Command.EntityId,
+                            envelope.UserId,
                             envelope.Command.Data?.GetProperty("name").GetString() ?? string.Empty,
                             envelope.Command.Data?.GetProperty("email").GetString() ?? string.Empty,
                             envelope.Command.Timestamp),
-                        CommandTypes.LogoutUser => new LogoutUserCommand(envelope.Command.EntityId, envelope.Command.Timestamp),
+                        CommandTypes.LogoutUser => new LogoutUserCommand(envelope.UserId, envelope.Command.Timestamp),
                         _ => throw new ArgumentException("Unknown Command.Type!", nameof(queueMessage))
                     },
                     EntityTypes.UserSettings => envelope.Command.Type switch

--- a/domain-service/src/DomainService.Domain/Commands/Commands.cs
+++ b/domain-service/src/DomainService.Domain/Commands/Commands.cs
@@ -6,7 +6,7 @@ namespace DomainService.Domain.Commands
 {
     public sealed record CompleteTaskCommand(string TaskId, string UserId, long Timestamp) : ICommand<Unit>;
 
-    public sealed record CreateTaskCommand(string TaskId, JsonElement? Data, string UserId, long Timestamp) : ICommand<Unit>;
+    public sealed record CreateTaskCommand(JsonElement? Data, string UserId, long Timestamp) : ICommand<Unit>;
 
     public sealed record LoginUserCommand(string UserId, string Name, string Email, long Timestamp) : ICommand<Unit>;
 

--- a/domain-service/src/DomainService.Domain/Commands/Commands.cs
+++ b/domain-service/src/DomainService.Domain/Commands/Commands.cs
@@ -4,16 +4,16 @@ using System.Text.Json;
 
 namespace DomainService.Domain.Commands
 {
-    public sealed record CompleteTaskCommand(string TaskId, string UserId, long Timestamp) : ICommand<Unit>;
+    public sealed record CompleteTaskCommand(string TaskId, string UserId, long Timestamp, string IdempotencyKey) : ICommand<Unit>;
 
-    public sealed record CreateTaskCommand(JsonElement? Data, string UserId, long Timestamp) : ICommand<Unit>;
+    public sealed record CreateTaskCommand(JsonElement? Data, string UserId, long Timestamp, string IdempotencyKey) : ICommand<Unit>;
 
-    public sealed record LoginUserCommand(string UserId, string Name, string Email, long Timestamp) : ICommand<Unit>;
+    public sealed record LoginUserCommand(string UserId, string Name, string Email, long Timestamp, string IdempotencyKey) : ICommand<Unit>;
 
-    public sealed record LogoutUserCommand(string UserId, long Timestamp) : ICommand<Unit>;
+    public sealed record LogoutUserCommand(string UserId, long Timestamp, string IdempotencyKey) : ICommand<Unit>;
 
-    public sealed record UpdateTaskCommand(string TaskId, JsonElement? Data, string UserId, long Timestamp) : ICommand<Unit>;
+    public sealed record UpdateTaskCommand(string TaskId, JsonElement? Data, string UserId, long Timestamp, string IdempotencyKey) : ICommand<Unit>;
 
-    public sealed record UpdateUserSettingsCommand(JsonElement? Data, string UserId, long Timestamp) : ICommand<Unit>;
+    public sealed record UpdateUserSettingsCommand(JsonElement? Data, string UserId, long Timestamp, string IdempotencyKey) : ICommand<Unit>;
 
 }

--- a/domain-service/src/DomainService.FunctionApp/Repositories/TableTaskEventRepository.cs
+++ b/domain-service/src/DomainService.FunctionApp/Repositories/TableTaskEventRepository.cs
@@ -28,8 +28,19 @@ internal sealed class TableTaskEventRepository(TableClient table) : ITaskEventRe
         var entity = new TableEntity(ev.EntityId, ev.Id)
         {
             {"UserId", ev.UserId},
-            {"Data", JsonSerializer.Serialize(ev)}
+            {"Data", JsonSerializer.Serialize(ev)},
+            {"IdempotencyKey", ev.IdempotencyKey}
         };
         await _table.AddEntityAsync(entity, ct);
+    }
+
+    public async Task<bool> Exists(string idempotencyKey, CancellationToken ct)
+    {
+        var filter = $"IdempotencyKey eq '{idempotencyKey}'";
+        await foreach (var _ in _table.QueryAsync<TableEntity>(filter: filter, maxPerPage: 1, cancellationToken: ct))
+        {
+            return true;
+        }
+        return false;
     }
 }

--- a/domain-service/src/DomainService.FunctionApp/Repositories/TableUserEventRepository.cs
+++ b/domain-service/src/DomainService.FunctionApp/Repositories/TableUserEventRepository.cs
@@ -23,7 +23,8 @@ internal sealed class TableUserEventRepository(TableClient table) : IUserEventRe
         var entity = new TableEntity(ev.EntityId, ev.Id)
         {
             {"UserId", ev.UserId},
-            {"Data", JsonSerializer.Serialize(ev)}
+            {"Data", JsonSerializer.Serialize(ev)},
+            {"IdempotencyKey", ev.IdempotencyKey}
         };
         await _table.AddEntityAsync(entity, ct);
     }

--- a/domain-service/src/DomainService.Interfaces/IEvent.cs
+++ b/domain-service/src/DomainService.Interfaces/IEvent.cs
@@ -11,4 +11,5 @@ public interface IEvent
     JsonElement? Data { get; }
     long Timestamp { get; }
     string UserId { get; }
+    string IdempotencyKey { get; }
 }

--- a/domain-service/src/DomainService.Interfaces/ITaskEventRepository.cs
+++ b/domain-service/src/DomainService.Interfaces/ITaskEventRepository.cs
@@ -4,4 +4,5 @@ public interface ITaskEventRepository
 {
     Task<IReadOnlyList<IEvent>> Get(string taskId, CancellationToken ct);
     Task Add(IEvent ev, CancellationToken ct);
+    Task<bool> Exists(string idempotencyKey, CancellationToken ct);
 }

--- a/domain-service/src/DomainService.Interfaces/Models.cs
+++ b/domain-service/src/DomainService.Interfaces/Models.cs
@@ -2,6 +2,6 @@ using System.Text.Json;
 
 namespace DomainService.Interfaces;
 
-public sealed record Command(string Id, string EntityId, string EntityType, string Type, JsonElement? Data, long Timestamp);
+public sealed record Command(string Id, string EntityType, string Type, JsonElement? Data, long Timestamp);
 public sealed record CommandEnvelope(string UserId, Command Command);
 public sealed record Event(string Id, string EntityId, string EntityType, string Type, JsonElement? Data, long Timestamp, string UserId) : IEvent;

--- a/domain-service/src/DomainService.Interfaces/Models.cs
+++ b/domain-service/src/DomainService.Interfaces/Models.cs
@@ -4,4 +4,4 @@ namespace DomainService.Interfaces;
 
 public sealed record Command(string Id, string EntityType, string Type, JsonElement? Data, long Timestamp);
 public sealed record CommandEnvelope(string UserId, Command Command);
-public sealed record Event(string Id, string EntityId, string EntityType, string Type, JsonElement? Data, long Timestamp, string UserId) : IEvent;
+public sealed record Event(string Id, string EntityId, string EntityType, string Type, JsonElement? Data, long Timestamp, string UserId, string IdempotencyKey) : IEvent;

--- a/domain-service/tests/DomainService.Tests/HandlersTests.cs
+++ b/domain-service/tests/DomainService.Tests/HandlersTests.cs
@@ -12,11 +12,12 @@ public class HandlersTests
         var repo = new InMemoryTaskRepo();
         var queue = new InMemoryQueue();
         ICommandHandler<CreateTaskCommand> handler = new CreateTask(repo, queue);
-        var cmd = new CreateTaskCommand("t1", JsonDocument.Parse("{\"title\":\"t\",\"notes\":\"n\",\"category\":\"c\"}").RootElement, "u1", 1);
+        var cmd = new CreateTaskCommand(JsonDocument.Parse("{\"title\":\"t\",\"notes\":\"n\",\"category\":\"c\"}").RootElement, "u1", 1);
         await handler.Handle(cmd, CancellationToken.None);
         Assert.Single(repo.Events);
         Assert.Single(queue.Events);
         Assert.Equal("task-created", repo.Events[0].Type);
+        Assert.False(string.IsNullOrWhiteSpace(repo.Events[0].EntityId));
     }
 
     [Fact]

--- a/domain-service/tests/DomainService.Tests/HandlersTests.cs
+++ b/domain-service/tests/DomainService.Tests/HandlersTests.cs
@@ -12,7 +12,7 @@ public class HandlersTests
         var repo = new InMemoryTaskRepo();
         var queue = new InMemoryQueue();
         ICommandHandler<CreateTaskCommand> handler = new CreateTask(repo, queue);
-        var cmd = new CreateTaskCommand(JsonDocument.Parse("{\"title\":\"t\",\"notes\":\"n\",\"category\":\"c\"}").RootElement, "u1", 1);
+        var cmd = new CreateTaskCommand(JsonDocument.Parse("{\"title\":\"t\",\"notes\":\"n\",\"category\":\"c\"}").RootElement, "u1", 1, "ik-create");
         await handler.Handle(cmd, CancellationToken.None);
         Assert.Single(repo.Events);
         Assert.Single(queue.Events);
@@ -21,14 +21,27 @@ public class HandlersTests
     }
 
     [Fact]
+    public async Task CreateTask_ignores_duplicate_idempotency_key()
+    {
+        var repo = new InMemoryTaskRepo();
+        var queue = new InMemoryQueue();
+        ICommandHandler<CreateTaskCommand> handler = new CreateTask(repo, queue);
+        var cmd = new CreateTaskCommand(JsonDocument.Parse("{\"title\":\"t\"}").RootElement, "u1", 1, "ik-dup");
+        await handler.Handle(cmd, CancellationToken.None);
+        await handler.Handle(cmd, CancellationToken.None);
+        Assert.Single(repo.Events);
+        Assert.Single(queue.Events);
+    }
+
+    [Fact]
     public async Task UpdateTask_adds_event_when_exists()
     {
         var repo = new InMemoryTaskRepo();
         var queue = new InMemoryQueue();
-        var seed = new Event("e1", "t1", "task", "task-created", JsonDocument.Parse("{\"title\":\"t\"}").RootElement, 0, "u1");
+        var seed = new Event("e1", "t1", "task", "task-created", JsonDocument.Parse("{\"title\":\"t\"}").RootElement, 0, "u1", "ik-seed");
         await repo.Add(seed, CancellationToken.None);
         ICommandHandler<UpdateTaskCommand> handler = new UpdateTask(repo, queue);
-        var cmd = new UpdateTaskCommand("t1", JsonDocument.Parse("{\"notes\":\"n\"}").RootElement, "u1", 1);
+        var cmd = new UpdateTaskCommand("t1", JsonDocument.Parse("{\"notes\":\"n\"}").RootElement, "u1", 1, "ik-update");
         await handler.Handle(cmd, CancellationToken.None);
         Assert.Equal(2, repo.Events.Count);
         Assert.Equal("task-updated", repo.Events[1].Type);
@@ -39,10 +52,10 @@ public class HandlersTests
     {
         var repo = new InMemoryTaskRepo();
         var queue = new InMemoryQueue();
-        var seed = new Event("e1", "t1", "task", "task-created", JsonDocument.Parse("{\"title\":\"t\"}").RootElement, 0, "u1");
+        var seed = new Event("e1", "t1", "task", "task-created", JsonDocument.Parse("{\"title\":\"t\"}").RootElement, 0, "u1", "ik-seed");
         await repo.Add(seed, CancellationToken.None);
         ICommandHandler<CompleteTaskCommand> handler = new CompleteTask(repo, queue);
-        var cmd = new CompleteTaskCommand("t1", "u1", 1);
+        var cmd = new CompleteTaskCommand("t1", "u1", 1, "ik-complete");
         await handler.Handle(cmd, CancellationToken.None);
         Assert.Equal(2, repo.Events.Count);
         Assert.Equal("task-completed", repo.Events[1].Type);
@@ -53,10 +66,10 @@ public class HandlersTests
     {
         var repo = new InMemoryUserRepo();
         var queue = new InMemoryQueue();
-        var seed = new Event("e1", "u1", "user", "user-created", null, 0, "u1");
+        var seed = new Event("e1", "u1", "user", "user-created", null, 0, "u1", "ik-seed");
         await repo.Add(seed, CancellationToken.None);
         ICommandHandler<LoginUserCommand> handler = new LoginUser(repo, queue);
-        var cmd = new LoginUserCommand("u1", "n", "e", 1);
+        var cmd = new LoginUserCommand("u1", "n", "e", 1, "ik-login");
         await handler.Handle(cmd, CancellationToken.None);
         Assert.Equal(2, repo.Events.Count);
         Assert.Equal("user-logged-in", repo.Events[1].Type);
@@ -68,7 +81,7 @@ public class HandlersTests
         var repo = new InMemoryUserRepo();
         var queue = new InMemoryQueue();
         ICommandHandler<LogoutUserCommand> handler = new LogoutUser(repo, queue);
-        var cmd = new LogoutUserCommand("u1", 1);
+        var cmd = new LogoutUserCommand("u1", 1, "ik-logout");
         await handler.Handle(cmd, CancellationToken.None);
         Assert.Single(repo.Events);
         Assert.Equal("user-logged-out", repo.Events[0].Type);
@@ -80,7 +93,7 @@ public class HandlersTests
         var repo = new InMemoryUserRepo();
         var queue = new InMemoryQueue();
         ICommandHandler<UpdateUserSettingsCommand> handler = new UpdateUserSettings(repo, queue);
-        var cmd = new UpdateUserSettingsCommand(JsonDocument.Parse("{\"tasksPerCategory\":5}").RootElement, "u1", 1);
+        var cmd = new UpdateUserSettingsCommand(JsonDocument.Parse("{\"tasksPerCategory\":5}").RootElement, "u1", 1, "ik-settings");
         await handler.Handle(cmd, CancellationToken.None);
         Assert.Single(repo.Events);
         Assert.Equal("user-settings-updated", repo.Events[0].Type);
@@ -108,6 +121,11 @@ class InMemoryTaskRepo : ITaskEventRepository
     public Task<IReadOnlyList<IEvent>> Get(string taskId, CancellationToken ct)
     {
         return Task.FromResult<IReadOnlyList<IEvent>>([.. Events.Where(e => e.EntityId == taskId)]);
+    }
+
+    public Task<bool> Exists(string idempotencyKey, CancellationToken ct)
+    {
+        return Task.FromResult(Events.Any(e => e.IdempotencyKey == idempotencyKey));
     }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,11 +30,10 @@ export default function App() {
           },
         });
         const command = {
-          entityId: user.sub,
           entityType: 'user',
           type: 'logout-user',
         };
-        await fetch(`${baseUrl}/commands`, {
+        const res = await fetch(`${baseUrl}/commands`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -42,6 +41,7 @@ export default function App() {
           },
           body: JSON.stringify([command]),
         });
+        await res.json();
       } catch (err) {
         console.error(err);
       }

--- a/frontend/src/hooks/auth/useLoginUser.ts
+++ b/frontend/src/hooks/auth/useLoginUser.ts
@@ -42,12 +42,11 @@ export function useLoginUser() {
         const token: string = tokenResponse.access_token || tokenResponse;
         const expiresIn: number = tokenResponse.expires_in || 0;
         const command = {
-          entityId: user.sub,
           entityType: "user",
           type: "login-user",
           data: { name: user.name, email: user.email },
         };
-        await fetch(`${baseUrl}/commands`, {
+        const res = await fetch(`${baseUrl}/commands`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -55,6 +54,7 @@ export function useLoginUser() {
           },
           body: JSON.stringify([command]),
         });
+        await res.json();
         const expiresAt = Date.now() + expiresIn * 1000;
         localStorage.setItem(
           storageKey,

--- a/frontend/src/hooks/settings/useSettings.ts
+++ b/frontend/src/hooks/settings/useSettings.ts
@@ -107,7 +107,7 @@ export function useSettings() {
             scope: "openid profile email offline_access",
           },
         });
-        await fetch(`${apiBaseUrl}/commands`, {
+        const res = await fetch(`${apiBaseUrl}/commands`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -115,8 +115,12 @@ export function useSettings() {
           },
           body: JSON.stringify(commands),
         });
+        const { idempotencyKeys } = await res.json();
         if (!cancelled) {
-          dispatch({ type: "clear-commands" });
+          dispatch({ type: "set-idempotency-keys", keys: idempotencyKeys });
+          if (res.ok) {
+            dispatch({ type: "clear-commands" });
+          }
         }
       } catch (err) {
         if (

--- a/frontend/src/hooks/tasks/useTasks.ts
+++ b/frontend/src/hooks/tasks/useTasks.ts
@@ -105,7 +105,7 @@ export function useTasks() {
             scope: "openid profile email offline_access",
           },
         });
-        await fetch(`${apiBaseUrl}/commands`, {
+        const res = await fetch(`${apiBaseUrl}/commands`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -113,8 +113,12 @@ export function useTasks() {
           },
           body: JSON.stringify(commands),
         });
+        const { idempotencyKeys } = await res.json();
         if (!cancelled) {
-          dispatch({ type: "clear-commands" });
+          dispatch({ type: "set-idempotency-keys", keys: idempotencyKeys });
+          if (res.ok) {
+            dispatch({ type: "clear-commands" });
+          }
         }
       } catch (err) {
         if (

--- a/frontend/src/reducers/settings/settingsReducer.ts
+++ b/frontend/src/reducers/settings/settingsReducer.ts
@@ -18,12 +18,14 @@ type UpdateSettingsAction = {
   settings: Partial<Settings>;
 };
 type ClearCommandsAction = { type: "clear-commands" };
+type SetIdempotencyKeysAction = { type: "set-idempotency-keys"; keys: string[] };
 
 type Action =
   | SetSettingsAction
   | MergeSettingsAction
   | UpdateSettingsAction
-  | ClearCommandsAction;
+  | ClearCommandsAction
+  | SetIdempotencyKeysAction;
 
 export function settingsReducer(state: State = initialState, action: Action): State {
   switch (action.type) {
@@ -33,7 +35,6 @@ export function settingsReducer(state: State = initialState, action: Action): St
       return { ...state, settings: { ...state.settings, ...action.settings } };
     case "update-settings": {
       const cmd: Command = {
-        entityId: action.userId,
         entityType: "user-settings",
         type: "update-user-settings",
         data: action.settings,
@@ -45,6 +46,12 @@ export function settingsReducer(state: State = initialState, action: Action): St
     }
     case "clear-commands":
       return { ...state, commands: [] };
+    case "set-idempotency-keys": {
+      const cmds = state.commands.map((c, i) =>
+        c.idempotencyKey ? c : { ...c, idempotencyKey: action.keys[i] }
+      );
+      return { ...state, commands: cmds };
+    }
     default:
       return state;
   }

--- a/frontend/src/reducers/tasks/tasksReducer.test.ts
+++ b/frontend/src/reducers/tasks/tasksReducer.test.ts
@@ -91,7 +91,10 @@ describe("tasksReducer", () => {
       changes: { title: "b" },
     });
     expect(s2.tasks[0].title).toBe("b");
-    expect(s2.commands[0]).toMatchObject({ type: "update-task", entityId: "t1" });
+    expect(s2.commands[0]).toMatchObject({
+      type: "update-task",
+      data: { id: "t1", title: "b" },
+    });
   });
 
   it("completes task and queues command", () => {
@@ -104,6 +107,9 @@ describe("tasksReducer", () => {
       id: "t1",
     });
     expect(s2.tasks[0].done).toBe(true);
-    expect(s2.commands[0]).toMatchObject({ type: "complete-task", entityId: "t1" });
+    expect(s2.commands[0]).toMatchObject({
+      type: "complete-task",
+      data: { id: "t1" },
+    });
   });
 });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,10 +10,10 @@ export interface Task {
 }
 
 export interface Command {
-  entityId: string;
   entityType: string;
   type: string;
   data?: any;
+  idempotencyKey?: string;
 }
 
 export interface Settings {

--- a/prism-api/domain/command.go
+++ b/prism-api/domain/command.go
@@ -4,12 +4,11 @@ import "encoding/json"
 
 // Command represents a write request for the domain model.
 type Command struct {
-	IdempotencyKey string          `json:"idempotencyKey"`
-	EntityID       string          `json:"entityId"`
-	EntityType     string          `json:"entityType"`
-	Type           string          `json:"type"`
-	Data           json.RawMessage `json:"data,omitempty"`
-	Timestamp      int64           `json:"timestamp"`
+        IdempotencyKey string          `json:"idempotencyKey"`
+        EntityType     string          `json:"entityType"`
+        Type           string          `json:"type"`
+        Data           json.RawMessage `json:"data,omitempty"`
+        Timestamp      int64           `json:"timestamp"`
 }
 
 // CommandEnvelope wraps a command with the user performing it.

--- a/tests/integration/scenarios/create_edit_complete_task_test.go
+++ b/tests/integration/scenarios/create_edit_complete_task_test.go
@@ -11,27 +11,28 @@ import (
 func TestCreateEditCompleteTask(t *testing.T) {
 	client := newPrismApiClient(t)
 
-	taskID := fmt.Sprintf("task-%d", time.Now().UnixNano())
-	title := "task-title-" + taskID
-	// Create task
-	_, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", taskID), EntityType: "task", EntityID: taskID, Type: "create-task", Data: map[string]any{"title": title}}}, nil)
+        title := fmt.Sprintf("task-title-%d", time.Now().UnixNano())
+        // Create task
+        _, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", title), EntityType: "task", Type: "create-task", Data: map[string]any{"title": title}}}, nil)
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
 
 	// Wait for task to appear
-	pollTasks(t, client, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
-		for _, tk := range ts {
-			if tk.ID == taskID {
-				return tk.Title == title
-			}
-		}
-		return false
-	})
+        var taskID string
+        pollTasks(t, client, fmt.Sprintf("task with title %s to be created", title), func(ts []task) bool {
+                for _, tk := range ts {
+                        if tk.Title == title {
+                                taskID = tk.ID
+                                return true
+                        }
+                }
+                return false
+        })
 
 	// Edit task title
 	newTitle := title + " updated"
-	_, err = client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-update-%s", taskID), EntityType: "task", EntityID: taskID, Type: "update-task", Data: map[string]any{"title": newTitle}}}, nil)
+	_, err = client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-update-%s", taskID), EntityType: "task", Type: "update-task", Data: map[string]any{"id": taskID, "title": newTitle}}}, nil)
 	if err != nil {
 		t.Fatalf("edit task: %v", err)
 	}
@@ -45,7 +46,7 @@ func TestCreateEditCompleteTask(t *testing.T) {
 	})
 
 	// Complete task
-	_, err = client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-complete-%s", taskID), EntityType: "task", EntityID: taskID, Type: "complete-task"}}, nil)
+	_, err = client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-complete-%s", taskID), EntityType: "task", Type: "complete-task", Data: map[string]any{"id": taskID}}}, nil)
 	if err != nil {
 		t.Fatalf("complete task: %v", err)
 	}

--- a/tests/integration/scenarios/helpers_test.go
+++ b/tests/integration/scenarios/helpers_test.go
@@ -11,11 +11,10 @@ import (
 )
 
 type command struct {
-	IdempotencyKey string         `json:"idempotencyKey,omitempty"`
-	EntityID       string         `json:"entityId,omitempty"`
-	EntityType     string         `json:"entityType"`
-	Type           string         `json:"type"`
-	Data           map[string]any `json:"data,omitempty"`
+        IdempotencyKey string         `json:"idempotencyKey,omitempty"`
+        EntityType     string         `json:"entityType"`
+        Type           string         `json:"type"`
+        Data           map[string]any `json:"data,omitempty"`
 }
 
 type task struct {

--- a/tests/integration/scenarios/ordering_and_idempotency_test.go
+++ b/tests/integration/scenarios/ordering_and_idempotency_test.go
@@ -11,26 +11,27 @@ import (
 func TestOrderingAndIdempotency(t *testing.T) {
 	client := newPrismApiClient(t)
 
-	taskID := fmt.Sprintf("idempotent-%d", time.Now().UnixNano())
-	title := fmt.Sprintf("title-%d", time.Now().UnixNano())
-	dedupe := fmt.Sprintf("ik-create-%d", time.Now().UnixNano())
-	payload := map[string]any{"title": title}
+        title := fmt.Sprintf("title-%d", time.Now().UnixNano())
+        dedupe := fmt.Sprintf("ik-create-%d", time.Now().UnixNano())
+        payload := map[string]any{"title": title}
 
-	if resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: dedupe, EntityType: "task", EntityID: taskID, Type: "create-task", Data: payload}}, nil); err != nil || resp.StatusCode >= 300 {
-		t.Fatalf("first create: status %d err %v", resp.StatusCode, err)
-	}
-	if resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: dedupe, EntityType: "task", EntityID: taskID, Type: "create-task", Data: payload}}, nil); err != nil || resp.StatusCode >= 300 {
-		t.Fatalf("second create: status %d err %v", resp.StatusCode, err)
-	}
+        if resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: dedupe, EntityType: "task", Type: "create-task", Data: payload}}, nil); err != nil || resp.StatusCode >= 300 {
+                t.Fatalf("first create: status %d err %v", resp.StatusCode, err)
+        }
+        if resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: dedupe, EntityType: "task", Type: "create-task", Data: payload}}, nil); err != nil || resp.StatusCode >= 300 {
+                t.Fatalf("second create: status %d err %v", resp.StatusCode, err)
+        }
 
-	tasks := pollTasks(t, client, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
-		for _, tk := range ts {
-			if tk.ID == taskID {
-				return tk.Title == title
-			}
-		}
-		return false
-	})
+        var taskID string
+        tasks := pollTasks(t, client, fmt.Sprintf("task with title %s to be created", title), func(ts []task) bool {
+                for _, tk := range ts {
+                        if tk.Title == title {
+                                taskID = tk.ID
+                                return true
+                        }
+                }
+                return false
+        })
 
 	count := 0
 	for _, tk := range tasks {
@@ -45,7 +46,7 @@ func TestOrderingAndIdempotency(t *testing.T) {
 	titles := []string{title + "-a", title + "-b", title + "-c"}
 	for i, tt := range titles {
 		key := fmt.Sprintf("ik-update-%d", i)
-		if resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: key, EntityType: "task", EntityID: taskID, Type: "update-task", Data: map[string]any{"title": tt}}}, nil); err != nil || resp.StatusCode >= 300 {
+                if resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: key, EntityType: "task", Type: "update-task", Data: map[string]any{"id": taskID, "title": tt}}}, nil); err != nil || resp.StatusCode >= 300 {
 			t.Fatalf("edit %d: status %d err %v", i, resp.StatusCode, err)
 		}
 		// Ensure each update is observed before issuing the next one

--- a/tests/integration/scenarios/projection_eventual_consistency_test.go
+++ b/tests/integration/scenarios/projection_eventual_consistency_test.go
@@ -11,9 +11,9 @@ func TestProjectionEventualConsistency(t *testing.T) {
 	client := newPrismApiClient(t)
 	timeout := getPollTimeout(t)
 
-        title := fmt.Sprintf("consistency-title-%d", time.Now().UnixNano())
+	title := fmt.Sprintf("consistency-title-%d", time.Now().UnixNano())
 	start := time.Now()
-        resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", title), EntityType: "task", Type: "create-task", Data: map[string]any{"title": title}}}, nil)
+	resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", title), EntityType: "task", Type: "create-task", Data: map[string]any{"title": title}}}, nil)
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
@@ -21,16 +21,14 @@ func TestProjectionEventualConsistency(t *testing.T) {
 		t.Fatalf("unexpected status %d", resp.StatusCode)
 	}
 
-        var taskID string
-        pollTasks(t, client, fmt.Sprintf("task with title %s to be created", title), func(ts []task) bool {
-                for _, tk := range ts {
-                        if tk.Title == title {
-                                taskID = tk.ID
-                                return true
-                        }
-                }
-                return false
-        })
+	pollTasks(t, client, fmt.Sprintf("task with title %s to be created", title), func(ts []task) bool {
+		for _, tk := range ts {
+			if tk.Title == title {
+				return true
+			}
+		}
+		return false
+	})
 	dur := time.Since(start)
 	if dur > timeout {
 		t.Fatalf("projection took %v, exceeds timeout %v", dur, timeout)

--- a/tests/integration/scenarios/projection_eventual_consistency_test.go
+++ b/tests/integration/scenarios/projection_eventual_consistency_test.go
@@ -11,10 +11,9 @@ func TestProjectionEventualConsistency(t *testing.T) {
 	client := newPrismApiClient(t)
 	timeout := getPollTimeout(t)
 
-	taskID := fmt.Sprintf("consistency-%d", time.Now().UnixNano())
-	title := "consistency-title-" + taskID
+        title := fmt.Sprintf("consistency-title-%d", time.Now().UnixNano())
 	start := time.Now()
-	resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", taskID), EntityType: "task", EntityID: taskID, Type: "create-task", Data: map[string]any{"title": title}}}, nil)
+        resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", title), EntityType: "task", Type: "create-task", Data: map[string]any{"title": title}}}, nil)
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
@@ -22,14 +21,16 @@ func TestProjectionEventualConsistency(t *testing.T) {
 		t.Fatalf("unexpected status %d", resp.StatusCode)
 	}
 
-	pollTasks(t, client, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
-		for _, tk := range ts {
-			if tk.ID == taskID {
-				return tk.Title == title
-			}
-		}
-		return false
-	})
+        var taskID string
+        pollTasks(t, client, fmt.Sprintf("task with title %s to be created", title), func(ts []task) bool {
+                for _, tk := range ts {
+                        if tk.Title == title {
+                                taskID = tk.ID
+                                return true
+                        }
+                }
+                return false
+        })
 	dur := time.Since(start)
 	if dur > timeout {
 		t.Fatalf("projection took %v, exceeds timeout %v", dur, timeout)

--- a/tests/integration/scenarios/resilience_backpressure_test.go
+++ b/tests/integration/scenarios/resilience_backpressure_test.go
@@ -29,8 +29,8 @@ func TestResilienceBackpressure(t *testing.T) {
 	}
 	t.Cleanup(func() { dc("start", "domain-service") })
 
-        title := fmt.Sprintf("backpressure-title-%d", time.Now().UnixNano())
-        resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", title), EntityType: "task", Type: "create-task", Data: map[string]any{"title": title}}}, nil)
+	title := fmt.Sprintf("backpressure-title-%d", time.Now().UnixNano())
+	resp, err := client.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", title), EntityType: "task", Type: "create-task", Data: map[string]any{"title": title}}}, nil)
 	if err != nil {
 		t.Fatalf("post command: %v", err)
 	}
@@ -42,16 +42,14 @@ func TestResilienceBackpressure(t *testing.T) {
 		t.Fatalf("restart domain-service: %v", err)
 	}
 	start := time.Now()
-        var taskID string
-        pollTasks(t, client, fmt.Sprintf("task with title %s to appear after restart", title), func(ts []task) bool {
-                for _, tk := range ts {
-                        if tk.Title == title {
-                                taskID = tk.ID
-                                return true
-                        }
-                }
-                return false
-        })
+	pollTasks(t, client, fmt.Sprintf("task with title %s to appear after restart", title), func(ts []task) bool {
+		for _, tk := range ts {
+			if tk.Title == title {
+				return true
+			}
+		}
+		return false
+	})
 	dur := time.Since(start)
 	if dur > timeout {
 		t.Fatalf("queue drained in %v, exceeds timeout %v", dur, timeout)

--- a/tests/integration/scenarios/streaming_live_updates_test.go
+++ b/tests/integration/scenarios/streaming_live_updates_test.go
@@ -12,20 +12,21 @@ import (
 func TestStreamingLiveUpdates(t *testing.T) {
 	prismApiClient := newPrismApiClient(t)
 
-	// Create a task to mutate
-	taskID := fmt.Sprintf("stream-%d", time.Now().UnixNano())
-	title := "stream-title-" + taskID
-	if _, err := prismApiClient.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", taskID), EntityType: "task", EntityID: taskID, Type: "create-task", Data: map[string]any{"title": title}}}, nil); err != nil {
-		t.Fatalf("create task: %v", err)
-	}
-	pollTasks(t, prismApiClient, fmt.Sprintf("task %s to be created with title %s", taskID, title), func(ts []task) bool {
-		for _, tk := range ts {
-			if tk.ID == taskID {
-				return tk.Title == title
-			}
-		}
-		return false
-	})
+        // Create a task to mutate
+        title := fmt.Sprintf("stream-title-%d", time.Now().UnixNano())
+        if _, err := prismApiClient.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-create-%s", title), EntityType: "task", Type: "create-task", Data: map[string]any{"title": title}}}, nil); err != nil {
+                t.Fatalf("create task: %v", err)
+        }
+        var taskID string
+        pollTasks(t, prismApiClient, fmt.Sprintf("task with title %s to be created", title), func(ts []task) bool {
+                for _, tk := range ts {
+                        if tk.Title == title {
+                                taskID = tk.ID
+                                return true
+                        }
+                }
+                return false
+        })
 
 	streamServiceClient := newStreamServiceClient(t)
 	req, err := http.NewRequest(http.MethodGet, streamServiceClient.BaseURL+"/stream", nil)
@@ -60,10 +61,10 @@ func TestStreamingLiveUpdates(t *testing.T) {
 	}()
 
 	// mutate the task
-	newTitle := title + "-sse"
-	if _, err := prismApiClient.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-update-%s", taskID), EntityType: "task", EntityID: taskID, Type: "update-task", Data: map[string]any{"title": newTitle}}}, nil); err != nil {
-		t.Fatalf("edit task: %v", err)
-	}
+        newTitle := title + "-sse"
+        if _, err := prismApiClient.PostJSON("/api/commands", []command{{IdempotencyKey: fmt.Sprintf("ik-update-%s", taskID), EntityType: "task", Type: "update-task", Data: map[string]any{"id": taskID, "title": newTitle}}}, nil); err != nil {
+                t.Fatalf("edit task: %v", err)
+        }
 
 	select {
 	case ev := <-eventCh:


### PR DESCRIPTION
## Summary
- remove `entityId` from client commands and add `idempotencyKey`
- return idempotency keys from Prism API and dedupe retries via Redis
- generate entity IDs within Domain Service after persisting events

## Testing
- `npm test` *(fails: vitest: not found)*
- `go test ./...` (prism-api)
- `go test ./...` (read-model-updater)
- `go test ./...` (stream-service)
- `go test ./...` (tests) *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f08922d48333a0377f463e1d40cd