### PR TITLE
Preserve idempotency key alignment in reducers

### DIFF
--- a/frontend/src/reducers/settings/settingsReducer.test.ts
+++ b/frontend/src/reducers/settings/settingsReducer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { settingsReducer, settingsInitialState } from ".";
 
 describe("settingsReducer", () => {
-  it("maps returned idempotency keys only to commands missing them", () => {
+  it("preserves index alignment when applying idempotency keys", () => {
     const s1 = settingsReducer(settingsInitialState, {
       type: "update-settings",
       userId: "u1",
@@ -19,7 +19,7 @@ describe("settingsReducer", () => {
     };
     const s4 = settingsReducer(s3, {
       type: "set-idempotency-keys",
-      keys: ["k2"],
+      keys: ["k1", "k2"],
     });
     expect(s4.commands[0].idempotencyKey).toBe("k1");
     expect(s4.commands[1].idempotencyKey).toBe("k2");

--- a/frontend/src/reducers/settings/settingsReducer.ts
+++ b/frontend/src/reducers/settings/settingsReducer.ts
@@ -49,9 +49,9 @@ export function settingsReducer(state: State = initialState, action: Action): St
     case "set-idempotency-keys": {
       let j = 0;
       const cmds = state.commands.map((c) => {
-        if (c.idempotencyKey) return c;
         const key = action.keys[j++];
-        return key ? { ...c, idempotencyKey: key } : c;
+        if (c.idempotencyKey || !key) return c;
+        return { ...c, idempotencyKey: key };
       });
       return { ...state, commands: cmds };
     }

--- a/frontend/src/reducers/tasks/tasksReducer.test.ts
+++ b/frontend/src/reducers/tasks/tasksReducer.test.ts
@@ -113,7 +113,7 @@ describe("tasksReducer", () => {
     });
   });
 
-  it("maps returned idempotency keys only to commands missing them", () => {
+  it("preserves index alignment when applying idempotency keys", () => {
     const s1 = tasksReducer(initialState, {
       type: "add-task",
       partial: { title: "a", notes: "", category: "normal" },
@@ -128,7 +128,7 @@ describe("tasksReducer", () => {
     };
     const s4 = tasksReducer(s3, {
       type: "set-idempotency-keys",
-      keys: ["k2"],
+      keys: ["k1", "k2"],
     });
     expect(s4.commands[0].idempotencyKey).toBe("k1");
     expect(s4.commands[1].idempotencyKey).toBe("k2");

--- a/frontend/src/reducers/tasks/tasksReducer.ts
+++ b/frontend/src/reducers/tasks/tasksReducer.ts
@@ -130,9 +130,9 @@ export function tasksReducer(state: State = initialState, action: Action): State
     case "set-idempotency-keys": {
       let j = 0;
       const cmds = state.commands.map((c) => {
-        if (c.idempotencyKey) return c;
         const key = action.keys[j++];
-        return key ? { ...c, idempotencyKey: key } : c;
+        if (c.idempotencyKey || !key) return c;
+        return { ...c, idempotencyKey: key };
       });
       return { ...state, commands: cmds };
     }


### PR DESCRIPTION
## Summary
- maintain index alignment when assigning idempotency keys to tasks
- maintain index alignment when assigning idempotency keys to settings commands

## Testing
- `go test ./...` (failed: no output after dependency download)
- `go test ./...` in `read-model-updater` (failed: no output after dependency download)
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bb1344618c8333928c65922a1905c6