### PR TITLE
fix: ignore stale completion updates

### DIFF
--- a/frontend/src/components/Board/Board.test.tsx
+++ b/frontend/src/components/Board/Board.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import Board, { aria } from '.';
+import Board, { aria, handleDragEnd } from '.';
 import type { Task } from '../../types';
 
 describe('Board', () => {
@@ -39,6 +39,23 @@ describe('Board', () => {
     vi.runAllTimers();
     expect(completeTask).toHaveBeenCalledWith('1');
     vi.useRealTimers();
+  });
+
+  it('uncompletes task when moved out of done lane', () => {
+    const tasks: Task[] = [
+      { id: '1', title: 'Done', category: 'fun', notes: '', order: 0, done: true }
+    ];
+    const updateTask = vi.fn();
+    const ev: any = {
+      active: { id: '1' },
+      over: { id: undefined, data: { current: { category: 'normal' } } }
+    };
+    handleDragEnd(ev, tasks, updateTask, vi.fn());
+    expect(updateTask).toHaveBeenCalledWith('1', {
+      category: 'normal',
+      order: 0,
+      done: false,
+    });
   });
 });
 

--- a/frontend/src/components/Board/index.tsx
+++ b/frontend/src/components/Board/index.tsx
@@ -1,2 +1,2 @@
-export { default } from './Board';
+export { default, handleDragEnd } from './Board';
 export { aria } from './aria';

--- a/frontend/src/reducers/settings/settingsReducer.test.ts
+++ b/frontend/src/reducers/settings/settingsReducer.test.ts
@@ -24,4 +24,15 @@ describe("settingsReducer", () => {
     expect(s4.commands[0].idempotencyKey).toBe("k1");
     expect(s4.commands[1].idempotencyKey).toBe("k2");
   });
+
+  it("queues command when toggling show done", () => {
+    const s1 = settingsReducer(settingsInitialState, {
+      type: "update-settings",
+      userId: "u1",
+      settings: { showDoneTasks: true },
+    });
+    expect(s1.settings.showDoneTasks).toBe(true);
+    expect(s1.commands).toHaveLength(1);
+    expect(s1.commands[0].data).toEqual({ showDoneTasks: true });
+  });
 });

--- a/prism-api/storage/storage_test.go
+++ b/prism-api/storage/storage_test.go
@@ -1,0 +1,16 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestDecodeSettingsEntity(t *testing.T) {
+	data := []byte(`{"PartitionKey":"u1","RowKey":"u1","TasksPerCategory":5,"ShowDoneTasks":true}`)
+	s, err := decodeSettingsEntity(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.TasksPerCategory != 5 || !s.ShowDoneTasks {
+		t.Fatalf("unexpected settings: %+v", s)
+	}
+}

--- a/read-model-updater/domain/apply.go
+++ b/read-model-updater/domain/apply.go
@@ -247,14 +247,20 @@ func Apply(ctx context.Context, st Storage, ev Event) error {
 			return err
 		}
 		if ent == nil {
-			ent = &UserSettingsEntity{Entity: Entity{PartitionKey: rk, RowKey: rk}, EventTimestamp: ev.Timestamp, EventTimestampType: EdmInt64}
+			ent = &UserSettingsEntity{
+				Entity:               Entity{PartitionKey: rk, RowKey: rk},
+				TasksPerCategory:     0,
+				TasksPerCategoryType: EdmInt32,
+				ShowDoneTasks:        false,
+				ShowDoneTasksType:    EdmBoolean,
+				EventTimestamp:       ev.Timestamp,
+				EventTimestampType:   EdmInt64,
+			}
 			if s.TasksPerCategory != nil {
 				ent.TasksPerCategory = *s.TasksPerCategory
-				ent.TasksPerCategoryType = EdmInt32
 			}
 			if s.ShowDoneTasks != nil {
 				ent.ShowDoneTasks = *s.ShowDoneTasks
-				ent.ShowDoneTasksType = EdmBoolean
 			}
 			return st.UpsertUserSettings(ctx, *ent)
 		}

--- a/read-model-updater/domain/apply.go
+++ b/read-model-updater/domain/apply.go
@@ -134,12 +134,12 @@ func Apply(ctx context.Context, st Storage, ev Event) error {
 			if eventData.Category != nil && ent.Category == "" {
 				upd.Category = eventData.Category
 			}
-			if eventData.Order != nil && ent.Order == 0 {
+			if eventData.Order != nil && ent.OrderType == "" {
 				upd.Order = eventData.Order
 				t := EdmInt32
 				upd.OrderType = &t
 			}
-			if eventData.Done != nil && !ent.Done {
+			if eventData.Done != nil && ent.DoneType == "" {
 				upd.Done = eventData.Done
 				t := EdmBoolean
 				upd.DoneType = &t

--- a/read-model-updater/domain/apply_test.go
+++ b/read-model-updater/domain/apply_test.go
@@ -226,7 +226,7 @@ func TestApplyTaskUpdatedMergesStaleFields(t *testing.T) {
 	}
 }
 
-func TestApplyTaskUpdatedMergesStaleDone(t *testing.T) {
+func TestApplyTaskUpdatedIgnoresStaleDone(t *testing.T) {
 	fs := &fakeStore{tasks: map[string]TaskEntity{"t1": {
 		Entity:         Entity{PartitionKey: "u1", RowKey: "t1"},
 		Done:           false,
@@ -241,7 +241,7 @@ func TestApplyTaskUpdatedMergesStaleDone(t *testing.T) {
 		t.Fatalf("apply: %v", err)
 	}
 	ent := fs.tasks["t1"]
-	if !ent.Done || ent.EventTimestamp != 5 {
+	if ent.Done || ent.EventTimestamp != 5 {
 		t.Fatalf("unexpected task entity: %#v", ent)
 	}
 }

--- a/read-model-updater/domain/apply_test.go
+++ b/read-model-updater/domain/apply_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 type fakeStore struct {
-	tasks          map[string]TaskEntity
-	settings       map[string]UserSettingsEntity
-	upsertTask     TaskEntity
-	insertTask     TaskEntity
-	upsertUser     UserEntity
-	upsertSettings UserSettingsEntity
+        tasks          map[string]TaskEntity
+        settings       map[string]UserSettingsEntity
+        upsertTask     TaskEntity
+        insertTask     TaskEntity
+        upsertUser     UserEntity
+       upsertSettings UserSettingsEntity
+       updateSettings UserSettingsUpdate
 }
 
 func (f *fakeStore) GetTask(ctx context.Context, pk, rk string) (*TaskEntity, error) {
@@ -114,7 +115,36 @@ func (f *fakeStore) UpsertUserSettings(ctx context.Context, ent UserSettingsEnti
 	return nil
 }
 
-func (f *fakeStore) UpdateUserSettings(ctx context.Context, ent UserSettingsUpdate) error { return nil }
+func (f *fakeStore) UpdateUserSettings(ctx context.Context, ent UserSettingsUpdate) error {
+       if f.settings == nil {
+               f.settings = map[string]UserSettingsEntity{}
+       }
+       cur, ok := f.settings[ent.RowKey]
+       if !ok {
+               cur = UserSettingsEntity{Entity: Entity{PartitionKey: ent.PartitionKey, RowKey: ent.RowKey}}
+       }
+       if ent.TasksPerCategory != nil {
+               cur.TasksPerCategory = *ent.TasksPerCategory
+               if ent.TasksPerCategoryType != nil {
+                       cur.TasksPerCategoryType = *ent.TasksPerCategoryType
+               }
+       }
+       if ent.ShowDoneTasks != nil {
+               cur.ShowDoneTasks = *ent.ShowDoneTasks
+               if ent.ShowDoneTasksType != nil {
+                       cur.ShowDoneTasksType = *ent.ShowDoneTasksType
+               }
+       }
+       if ent.EventTimestamp != nil {
+               cur.EventTimestamp = *ent.EventTimestamp
+               if ent.EventTimestampType != nil {
+                       cur.EventTimestampType = *ent.EventTimestampType
+               }
+       }
+       f.settings[ent.RowKey] = cur
+       f.updateSettings = ent
+       return nil
+}
 
 func TestApplyTaskCreated(t *testing.T) {
 	fs := &fakeStore{}
@@ -287,18 +317,45 @@ func TestApplyUserSettingsUpdatedIgnoresOldEvent(t *testing.T) {
 }
 
 func TestApplyUserSettingsUpdatedCreatesDefaults(t *testing.T) {
-	fs := &fakeStore{}
-	sdt := true
-	data := UserSettingsUpdatedEventData{ShowDoneTasks: &sdt}
-	payload, _ := json.Marshal(data)
-	ev := Event{Type: UserSettingsUpdated, UserID: "u1", EntityID: "u1", Data: payload, Timestamp: 1}
-	if err := Apply(context.Background(), fs, ev); err != nil {
-		t.Fatalf("apply: %v", err)
-	}
-	ent := fs.settings["u1"]
-	if ent.TasksPerCategory != 0 || ent.TasksPerCategoryType != EdmInt32 || !ent.ShowDoneTasks || ent.ShowDoneTasksType != EdmBoolean {
-		t.Fatalf("unexpected settings entity: %#v", ent)
-	}
+        fs := &fakeStore{}
+        sdt := true
+        data := UserSettingsUpdatedEventData{ShowDoneTasks: &sdt}
+        payload, _ := json.Marshal(data)
+        ev := Event{Type: UserSettingsUpdated, UserID: "u1", EntityID: "u1", Data: payload, Timestamp: 1}
+        if err := Apply(context.Background(), fs, ev); err != nil {
+                t.Fatalf("apply: %v", err)
+        }
+        ent := fs.settings["u1"]
+        if ent.TasksPerCategory != 0 || ent.TasksPerCategoryType != EdmInt32 || !ent.ShowDoneTasks || ent.ShowDoneTasksType != EdmBoolean {
+                t.Fatalf("unexpected settings entity: %#v", ent)
+        }
+}
+
+func TestApplyUserSettingsUpdatedUpdatesExisting(t *testing.T) {
+       fs := &fakeStore{settings: map[string]UserSettingsEntity{
+               "u1": {
+                       Entity:               Entity{PartitionKey: "u1", RowKey: "u1"},
+                       TasksPerCategory:     3,
+                       TasksPerCategoryType: EdmInt32,
+                       ShowDoneTasks:        false,
+                       ShowDoneTasksType:    EdmBoolean,
+                       EventTimestamp:       1,
+                       EventTimestampType:   EdmInt64,
+               },
+       }}
+       sdt := true
+       data := UserSettingsUpdatedEventData{ShowDoneTasks: &sdt}
+       payload, _ := json.Marshal(data)
+       ev := Event{Type: UserSettingsUpdated, UserID: "u1", EntityID: "u1", Data: payload, Timestamp: 2}
+       if err := Apply(context.Background(), fs, ev); err != nil {
+               t.Fatalf("apply: %v", err)
+       }
+       if fs.updateSettings.PartitionKey != "u1" || fs.updateSettings.ShowDoneTasks == nil || !*fs.updateSettings.ShowDoneTasks {
+               t.Fatalf("unexpected update payload: %#v", fs.updateSettings)
+       }
+       if fs.settings["u1"].ShowDoneTasks != true || fs.settings["u1"].EventTimestamp != 2 {
+               t.Fatalf("settings not updated: %#v", fs.settings["u1"])
+       }
 }
 
 func ptrString(s string) *string { return &s }

--- a/read-model-updater/domain/apply_test.go
+++ b/read-model-updater/domain/apply_test.go
@@ -203,7 +203,7 @@ func TestApplyTaskUpdatedStaleEventDoesNotOverride(t *testing.T) {
 	}
 }
 
-func TestApplyTaskUpdatedMergesStaleFields(t *testing.T) {
+func TestApplyTaskUpdatedIgnoresStaleFields(t *testing.T) {
 	fs := &fakeStore{tasks: map[string]TaskEntity{"t1": {
 		Entity:         Entity{PartitionKey: "u1", RowKey: "t1"},
 		Title:          "a",
@@ -221,7 +221,7 @@ func TestApplyTaskUpdatedMergesStaleFields(t *testing.T) {
 		t.Fatalf("apply: %v", err)
 	}
 	ent := fs.tasks["t1"]
-	if ent.Notes != "note" || ent.EventTimestamp != 5 {
+	if ent.Notes == "note" || ent.EventTimestamp != 5 {
 		t.Fatalf("unexpected task entity: %#v", ent)
 	}
 }

--- a/read-model-updater/domain/apply_test.go
+++ b/read-model-updater/domain/apply_test.go
@@ -286,5 +286,20 @@ func TestApplyUserSettingsUpdatedIgnoresOldEvent(t *testing.T) {
 	}
 }
 
+func TestApplyUserSettingsUpdatedCreatesDefaults(t *testing.T) {
+	fs := &fakeStore{}
+	sdt := true
+	data := UserSettingsUpdatedEventData{ShowDoneTasks: &sdt}
+	payload, _ := json.Marshal(data)
+	ev := Event{Type: UserSettingsUpdated, UserID: "u1", EntityID: "u1", Data: payload, Timestamp: 1}
+	if err := Apply(context.Background(), fs, ev); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	ent := fs.settings["u1"]
+	if ent.TasksPerCategory != 0 || ent.TasksPerCategoryType != EdmInt32 || !ent.ShowDoneTasks || ent.ShowDoneTasksType != EdmBoolean {
+		t.Fatalf("unexpected settings entity: %#v", ent)
+	}
+}
+
 func ptrString(s string) *string { return &s }
 func ptrInt(i int) *int          { return &i }

--- a/tests/integration/scenarios/helpers_test.go
+++ b/tests/integration/scenarios/helpers_test.go
@@ -11,17 +11,18 @@ import (
 )
 
 type command struct {
-        IdempotencyKey string         `json:"idempotencyKey,omitempty"`
-        EntityType     string         `json:"entityType"`
-        Type           string         `json:"type"`
-        Data           map[string]any `json:"data,omitempty"`
+	IdempotencyKey string         `json:"idempotencyKey,omitempty"`
+	EntityType     string         `json:"entityType"`
+	Type           string         `json:"type"`
+	Data           map[string]any `json:"data,omitempty"`
 }
 
 type task struct {
-	ID    string `json:"id"`
-	Title string `json:"title"`
-	Notes string `json:"notes"`
-	Done  bool   `json:"done"`
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Notes    string `json:"notes"`
+	Done     bool   `json:"done"`
+	Category string `json:"category"`
 }
 
 func getPollTimeout(t *testing.T) time.Duration {

--- a/tests/integration/scenarios/reopen_completed_tasks_test.go
+++ b/tests/integration/scenarios/reopen_completed_tasks_test.go
@@ -1,0 +1,112 @@
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+)
+
+func TestReopenCompletedTasks(t *testing.T) {
+	connStr := os.Getenv("STORAGE_CONNECTION_STRING_LOCAL")
+	qName := os.Getenv("DOMAIN_EVENTS_QUEUE")
+	queue, err := azqueue.NewQueueClientFromConnectionString(connStr, qName, nil)
+	if err != nil {
+		t.Fatalf("queue client: %v", err)
+	}
+	apiClient := newPrismApiClient(t)
+
+	send := func(ev map[string]any) {
+		b, _ := json.Marshal(ev)
+		if _, err := queue.EnqueueMessage(context.Background(), string(b), nil); err != nil {
+			t.Fatalf("enqueue event: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	base := time.Now().UnixNano()
+	userID := "integration-user"
+	categories := []string{"cat1", "cat2", "cat3", "cat4"}
+	ids := make([]string, len(categories))
+
+	// create tasks
+	for i, cat := range categories {
+		id := fmt.Sprintf("reopen-%d-%d", i, base)
+		ids[i] = id
+		send(map[string]any{
+			"Id":         fmt.Sprintf("c%d", i),
+			"EntityId":   id,
+			"EntityType": "task",
+			"Type":       "task-created",
+			"Timestamp":  base + int64(i),
+			"UserId":     userID,
+			"Data":       map[string]any{"title": id, "category": cat, "order": i},
+		})
+	}
+
+	ts := base + 1000
+	// move tasks to done
+	for i, id := range ids {
+		send(map[string]any{
+			"Id":         fmt.Sprintf("d%d", i),
+			"EntityId":   id,
+			"EntityType": "task",
+			"Type":       "task-updated",
+			"Timestamp":  ts + int64(i),
+			"UserId":     userID,
+			"Data":       map[string]any{"category": "done", "order": i},
+		})
+		send(map[string]any{
+			"Id":         fmt.Sprintf("dc%d", i),
+			"EntityId":   id,
+			"EntityType": "task",
+			"Type":       "task-updated",
+			"Timestamp":  ts + int64(i) + 1,
+			"UserId":     userID,
+			"Data":       map[string]any{"done": true},
+		})
+	}
+
+	ts2 := ts + 1000
+	// reopen tasks
+	for i, id := range ids {
+		send(map[string]any{
+			"Id":         fmt.Sprintf("r%d", i),
+			"EntityId":   id,
+			"EntityType": "task",
+			"Type":       "task-updated",
+			"Timestamp":  ts2 + int64(i),
+			"UserId":     userID,
+			"Data":       map[string]any{"category": categories[i], "order": i, "done": false},
+		})
+	}
+
+	// stale completion events arrive late
+	for i, id := range ids {
+		send(map[string]any{
+			"Id":         fmt.Sprintf("s%d", i),
+			"EntityId":   id,
+			"EntityType": "task",
+			"Type":       "task-updated",
+			"Timestamp":  ts + int64(i),
+			"UserId":     userID,
+			"Data":       map[string]any{"done": true},
+		})
+	}
+
+	pollTasks(t, apiClient, "tasks reopened", func(tsks []task) bool {
+		found := 0
+		for i, id := range ids {
+			for _, tk := range tsks {
+				if tk.ID == id && tk.Category == categories[i] && !tk.Done {
+					found++
+				}
+			}
+		}
+		return found == len(ids)
+	})
+}

--- a/tests/integration/scenarios/user_settings_persistence_test.go
+++ b/tests/integration/scenarios/user_settings_persistence_test.go
@@ -36,17 +36,29 @@ func TestUserSettingsPersistence(t *testing.T) {
 
 	userID := "integration-user"
 	ts := time.Now().UnixNano()
-	send(map[string]any{
-		"Id":         "s1",
-		"EntityId":   userID,
-		"EntityType": "user-settings",
-		"Type":       "user-settings-updated",
-		"Timestamp":  ts,
-		"UserId":     userID,
-		"Data":       map[string]any{"showDoneTasks": true},
-	})
+        send(map[string]any{
+                "Id":         "s1",
+                "EntityId":   userID,
+                "EntityType": "user-settings",
+                "Type":       "user-settings-updated",
+                "Timestamp":  ts,
+                "UserId":     userID,
+                "Data":       map[string]any{"showDoneTasks": true},
+        })
 
-	pollSettings(t, apiClient, "show done updated", func(s settings) bool { return s.ShowDoneTasks })
+        pollSettings(t, apiClient, "show done enabled", func(s settings) bool { return s.ShowDoneTasks })
+
+        send(map[string]any{
+                "Id":         "s2",
+                "EntityId":   userID,
+                "EntityType": "user-settings",
+                "Type":       "user-settings-updated",
+                "Timestamp":  ts + 1,
+                "UserId":     userID,
+                "Data":       map[string]any{"showDoneTasks": false},
+        })
+
+        pollSettings(t, apiClient, "show done disabled", func(s settings) bool { return !s.ShowDoneTasks })
 }
 
 func pollSettings(t *testing.T, client *httpclient.Client, desc string, cond func(settings) bool) settings {

--- a/tests/integration/scenarios/user_settings_persistence_test.go
+++ b/tests/integration/scenarios/user_settings_persistence_test.go
@@ -1,0 +1,73 @@
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"prismtest/internal/httpclient"
+)
+
+type settings struct {
+	TasksPerCategory int  `json:"tasksPerCategory"`
+	ShowDoneTasks    bool `json:"showDoneTasks"`
+}
+
+func TestUserSettingsPersistence(t *testing.T) {
+	connStr := os.Getenv("STORAGE_CONNECTION_STRING_LOCAL")
+	qName := os.Getenv("DOMAIN_EVENTS_QUEUE")
+	queue, err := azqueue.NewQueueClientFromConnectionString(connStr, qName, nil)
+	if err != nil {
+		t.Fatalf("queue client: %v", err)
+	}
+	apiClient := newPrismApiClient(t)
+
+	send := func(ev map[string]any) {
+		b, _ := json.Marshal(ev)
+		if _, err := queue.EnqueueMessage(context.Background(), string(b), nil); err != nil {
+			t.Fatalf("enqueue event: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	userID := "integration-user"
+	ts := time.Now().UnixNano()
+	send(map[string]any{
+		"Id":         "s1",
+		"EntityId":   userID,
+		"EntityType": "user-settings",
+		"Type":       "user-settings-updated",
+		"Timestamp":  ts,
+		"UserId":     userID,
+		"Data":       map[string]any{"showDoneTasks": true},
+	})
+
+	pollSettings(t, apiClient, "show done updated", func(s settings) bool { return s.ShowDoneTasks })
+}
+
+func pollSettings(t *testing.T, client *httpclient.Client, desc string, cond func(settings) bool) settings {
+	deadline := time.Now().Add(getPollTimeout(t))
+	backoff := 200 * time.Millisecond
+	var (
+		st  settings
+		err error
+	)
+	for {
+		st = settings{}
+		_, err = client.GetJSON("/api/settings", &st)
+		if err == nil && cond(st) {
+			return st
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for settings for %s: last settings %+v: %v", desc, st, err)
+		}
+		time.Sleep(backoff)
+		if backoff < time.Second {
+			backoff *= 2
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- ignore stale `done` and `order` updates in read model updater
- test stale completion handling and reopen workflow

## Testing
- `go test ./domain -run Test -count=1` within `read-model-updater`
- `go vet ./domain` within `read-model-updater`
- `go test ./scenarios -run TestReopenCompletedTasks -count=1` *(fails: connection string is either blank or malformed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c8ff07c8333a858798a2c312b0a