### PR TITLE
Fix user settings persistence and add tests

### DIFF
--- a/prism-api/storage/storage_test.go
+++ b/prism-api/storage/storage_test.go
@@ -1,0 +1,16 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestDecodeSettingsEntity(t *testing.T) {
+	data := []byte(`{"PartitionKey":"u1","RowKey":"u1","TasksPerCategory":5,"ShowDoneTasks":true}`)
+	s, err := decodeSettingsEntity(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.TasksPerCategory != 5 || !s.ShowDoneTasks {
+		t.Fatalf("unexpected settings: %+v", s)
+	}
+}

--- a/read-model-updater/domain/apply.go
+++ b/read-model-updater/domain/apply.go
@@ -247,14 +247,20 @@ func Apply(ctx context.Context, st Storage, ev Event) error {
 			return err
 		}
 		if ent == nil {
-			ent = &UserSettingsEntity{Entity: Entity{PartitionKey: rk, RowKey: rk}, EventTimestamp: ev.Timestamp, EventTimestampType: EdmInt64}
+			ent = &UserSettingsEntity{
+				Entity:               Entity{PartitionKey: rk, RowKey: rk},
+				TasksPerCategory:     0,
+				TasksPerCategoryType: EdmInt32,
+				ShowDoneTasks:        false,
+				ShowDoneTasksType:    EdmBoolean,
+				EventTimestamp:       ev.Timestamp,
+				EventTimestampType:   EdmInt64,
+			}
 			if s.TasksPerCategory != nil {
 				ent.TasksPerCategory = *s.TasksPerCategory
-				ent.TasksPerCategoryType = EdmInt32
 			}
 			if s.ShowDoneTasks != nil {
 				ent.ShowDoneTasks = *s.ShowDoneTasks
-				ent.ShowDoneTasksType = EdmBoolean
 			}
 			return st.UpsertUserSettings(ctx, *ent)
 		}

--- a/read-model-updater/domain/apply_test.go
+++ b/read-model-updater/domain/apply_test.go
@@ -286,5 +286,20 @@ func TestApplyUserSettingsUpdatedIgnoresOldEvent(t *testing.T) {
 	}
 }
 
+func TestApplyUserSettingsUpdatedCreatesDefaults(t *testing.T) {
+	fs := &fakeStore{}
+	sdt := true
+	data := UserSettingsUpdatedEventData{ShowDoneTasks: &sdt}
+	payload, _ := json.Marshal(data)
+	ev := Event{Type: UserSettingsUpdated, UserID: "u1", EntityID: "u1", Data: payload, Timestamp: 1}
+	if err := Apply(context.Background(), fs, ev); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	ent := fs.settings["u1"]
+	if ent.TasksPerCategory != 0 || ent.TasksPerCategoryType != EdmInt32 || !ent.ShowDoneTasks || ent.ShowDoneTasksType != EdmBoolean {
+		t.Fatalf("unexpected settings entity: %#v", ent)
+	}
+}
+
 func ptrString(s string) *string { return &s }
 func ptrInt(i int) *int          { return &i }

--- a/tests/integration/scenarios/user_settings_persistence_test.go
+++ b/tests/integration/scenarios/user_settings_persistence_test.go
@@ -1,0 +1,73 @@
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"prismtest/internal/httpclient"
+)
+
+type settings struct {
+	TasksPerCategory int  `json:"tasksPerCategory"`
+	ShowDoneTasks    bool `json:"showDoneTasks"`
+}
+
+func TestUserSettingsPersistence(t *testing.T) {
+	connStr := os.Getenv("STORAGE_CONNECTION_STRING_LOCAL")
+	qName := os.Getenv("DOMAIN_EVENTS_QUEUE")
+	queue, err := azqueue.NewQueueClientFromConnectionString(connStr, qName, nil)
+	if err != nil {
+		t.Fatalf("queue client: %v", err)
+	}
+	apiClient := newPrismApiClient(t)
+
+	send := func(ev map[string]any) {
+		b, _ := json.Marshal(ev)
+		if _, err := queue.EnqueueMessage(context.Background(), string(b), nil); err != nil {
+			t.Fatalf("enqueue event: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	userID := "integration-user"
+	ts := time.Now().UnixNano()
+	send(map[string]any{
+		"Id":         "s1",
+		"EntityId":   userID,
+		"EntityType": "user-settings",
+		"Type":       "user-settings-updated",
+		"Timestamp":  ts,
+		"UserId":     userID,
+		"Data":       map[string]any{"showDoneTasks": true},
+	})
+
+	pollSettings(t, apiClient, "show done updated", func(s settings) bool { return s.ShowDoneTasks })
+}
+
+func pollSettings(t *testing.T, client *httpclient.Client, desc string, cond func(settings) bool) settings {
+	deadline := time.Now().Add(getPollTimeout(t))
+	backoff := 200 * time.Millisecond
+	var (
+		st  settings
+		err error
+	)
+	for {
+		st = settings{}
+		_, err = client.GetJSON("/api/settings", &st)
+		if err == nil && cond(st) {
+			return st
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for settings for %s: last settings %+v: %v", desc, st, err)
+		}
+		time.Sleep(backoff)
+		if backoff < time.Second {
+			backoff *= 2
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- map stored settings fields to API model so showDone persists
- ensure new user settings updates create default-typed entities
- cover user settings persistence with unit and integration tests

## Testing
- `go test ./...` (prism-api)
- `go test ./...` (read-model-updater)
- `go test ./...` (tests/integration) *(fails: TEST_JWT_SECRET must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4483d9b8833387a1dad929369792