### PR TITLE
Fix task completion state handling

### DIFF
--- a/domain-service/src/DomainService.Domain/TaskState.cs
+++ b/domain-service/src/DomainService.Domain/TaskState.cs
@@ -1,4 +1,5 @@
 using DomainService.Interfaces;
+using System.Linq;
 
 namespace DomainService.Domain;
 
@@ -16,7 +17,7 @@ internal static class TaskStateBuilder
     public static TaskState From(IEnumerable<IEvent> events)
     {
         var state = new TaskState();
-        foreach (var ev in events)
+        foreach (var ev in events.OrderBy(e => e.Timestamp))
         {
             Apply(state, ev);
         }
@@ -58,10 +59,8 @@ internal static class TaskStateBuilder
                     if (data.TryGetProperty("order", out var o) && o.TryGetInt32(out var oi)) {
                         state.Order = oi;
                     }
-                    if (data.TryGetProperty("done", out var d) && d.ValueKind == System.Text.Json.JsonValueKind.False) {
-                        state.Done = false;
-                    } else {
-                        state.Done = true;
+                    if (data.TryGetProperty("done", out var d)) {
+                        state.Done = d.ValueKind == System.Text.Json.JsonValueKind.True;
                     }
                 }
                 break;

--- a/domain-service/tests/DomainService.Tests/TaskStateBuilderTests.cs
+++ b/domain-service/tests/DomainService.Tests/TaskStateBuilderTests.cs
@@ -1,0 +1,32 @@
+using DomainService.Domain;
+using DomainService.Interfaces;
+using System.Text.Json;
+using Xunit;
+
+public class TaskStateBuilderTests
+{
+    [Fact]
+    public void From_orders_events_by_timestamp()
+    {
+        var created = new Event("e1", "t1", EntityTypes.Task, TaskEventTypes.Created,
+            JsonDocument.Parse("{\"title\":\"t\"}").RootElement, 0, "u1", "ik1");
+        var completed = new Event("e2", "t1", EntityTypes.Task, TaskEventTypes.Completed,
+            null, 2, "u1", "ik2");
+        var reopened = new Event("e3", "t1", EntityTypes.Task, TaskEventTypes.Updated,
+            JsonDocument.Parse("{\"done\":false}").RootElement, 3, "u1", "ik3");
+        // shuffled order
+        var state = TaskStateBuilder.From(new IEvent[] { completed, created, reopened });
+        Assert.False(state.Done);
+    }
+
+    [Fact]
+    public void Update_does_not_change_done_when_missing()
+    {
+        var created = new Event("e1", "t1", EntityTypes.Task, TaskEventTypes.Created,
+            JsonDocument.Parse("{\"title\":\"t\"}").RootElement, 0, "u1", "ik1");
+        var updated = new Event("e2", "t1", EntityTypes.Task, TaskEventTypes.Updated,
+            JsonDocument.Parse("{\"title\":\"new\"}").RootElement, 1, "u1", "ik2");
+        var final = TaskStateBuilder.From(new IEvent[] { created, updated });
+        Assert.False(final.Done);
+    }
+}


### PR DESCRIPTION
## Summary
- sort task events by timestamp when rebuilding state
- preserve existing `done` value when updates omit it
- add unit tests for TaskStateBuilder ordering and done flag behavior

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf04a5417c8333af152640bbb4b5cb