### PR TITLE
refactor: reopen tasks with a single update event

### DIFF
--- a/domain-service/src/DomainService.Domain/CommandHandlers/UpdateTask.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/UpdateTask.cs
@@ -2,6 +2,7 @@ using DomainService.Domain.Commands;
 using DomainService.Interfaces;
 using MediatR;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using DomainService.Domain;
 
 namespace DomainService.Domain.CommandHandlers;
@@ -17,26 +18,19 @@ internal sealed class UpdateTask(ITaskEventRepository taskRepo, IEventQueue even
         var state = TaskStateBuilder.From(events);
         if (state.Title == null) return Unit.Value;
 
-        var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Updated, request.Data, request.Timestamp, request.UserId, request.IdempotencyKey);
-        await _taskRepo.Add(ev, ct);
-        await _eventQueue.Add(ev, ct);
-
+        JsonElement? data = request.Data;
         if (state.Done && request.Data.HasValue &&
             request.Data.Value.TryGetProperty("category", out var c) &&
             c.GetString() != null && !string.Equals(c.GetString(), "done", StringComparison.OrdinalIgnoreCase))
         {
-            var reopen = new Event(
-                Guid.NewGuid().ToString(),
-                request.TaskId,
-                EntityTypes.Task,
-                TaskEventTypes.Updated,
-                JsonSerializer.SerializeToElement(new TaskStatusData(false)),
-                request.Timestamp,
-                request.UserId,
-                request.IdempotencyKey);
-            await _taskRepo.Add(reopen, ct);
-            await _eventQueue.Add(reopen, ct);
+            var obj = JsonNode.Parse(request.Data.Value.GetRawText())!.AsObject();
+            obj["done"] = false;
+            data = JsonSerializer.SerializeToElement(obj);
         }
+
+        var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Updated, data, request.Timestamp, request.UserId, request.IdempotencyKey);
+        await _taskRepo.Add(ev, ct);
+        await _eventQueue.Add(ev, ct);
         return Unit.Value;
     }
 }

--- a/domain-service/tests/DomainService.Tests/HandlersTests.cs
+++ b/domain-service/tests/DomainService.Tests/HandlersTests.cs
@@ -114,10 +114,13 @@ namespace DomainService.Tests
             ICommandHandler<UpdateTaskCommand> handler = new UpdateTask(repo, queue);
             var cmd = new UpdateTaskCommand("t1", JsonDocument.Parse("{\"category\":\"fun\"}").RootElement, "u1", 2, "ik-update");
             await handler.Handle(cmd, CancellationToken.None);
-            Assert.Equal(4, repo.Events.Count);
+            Assert.Equal(3, repo.Events.Count);
             Assert.Equal("task-updated", repo.Events[2].Type);
-            Assert.Equal("task-updated", repo.Events[3].Type);
-            Assert.Equal(2, queue.Events.Count);
+            Assert.Single(queue.Events);
+            Assert.Equal("task-updated", queue.Events[0].Type);
+            Assert.True(repo.Events[2].Data.HasValue);
+            Assert.Equal("fun", repo.Events[2].Data.Value.GetProperty("category").GetString());
+            Assert.False(repo.Events[2].Data.Value.GetProperty("done").GetBoolean());
         }
     }
 


### PR DESCRIPTION
## Summary
- merge reopen status into the initial task update when moving from the done column
- adjust tests to validate the single-event reopen behavior

## Testing
- `npm test` *(fails: vitest not found)*
- `go test ./...` (prism-api)
- `go test ./...` (read-model-updater)
- `go test ./...` (stream-service)
- `go test ./...` (tests) *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bfd5f192a083339e717a47b9f38f5b