### PR TITLE
Include auth headers in k6 perf tests

### DIFF
--- a/tests/perf/k6/api_mixed_read_write.js
+++ b/tests/perf/k6/api_mixed_read_write.js
@@ -17,13 +17,19 @@ export const options = {
 
 export default function () {
   const base = __ENV.PRISM_API_BASE || 'http://localhost';
+  const bearer = __ENV.TEST_BEARER;
+  const headers = {};
+  if (bearer) {
+    headers.Authorization = `Bearer ${bearer}`;
+  }
   if (Math.random() < 0.8) {
-    http.get(`${base}/api/tasks`);
+    http.get(`${base}/api/tasks`, { headers });
   } else {
+    const postHeaders = Object.assign({ 'Content-Type': 'application/json' }, headers);
     http.post(
       `${base}/api/commands`,
       JSON.stringify({ type: 'CreateTask', payload: { title: 'k6 task' } }),
-      { headers: { 'Content-Type': 'application/json' } },
+      { headers: postHeaders },
     );
   }
 }

--- a/tests/perf/k6/api_read_heavy.js
+++ b/tests/perf/k6/api_read_heavy.js
@@ -16,13 +16,19 @@ export const options = {
 
 export default function () {
   const base = __ENV.PRISM_API_BASE || 'http://localhost';
+  const bearer = __ENV.TEST_BEARER;
+  const headers = {};
+  if (bearer) {
+    headers.Authorization = `Bearer ${bearer}`;
+  }
   if (Math.random() < 0.95) {
-    http.get(`${base}/api/tasks`);
+    http.get(`${base}/api/tasks`, { headers });
   } else {
+    const postHeaders = Object.assign({ 'Content-Type': 'application/json' }, headers);
     http.post(
       `${base}/api/commands`,
       JSON.stringify({ type: 'CreateTask', payload: { title: 'k6 task' } }),
-      { headers: { 'Content-Type': 'application/json' } },
+      { headers: postHeaders },
     );
   }
 }

--- a/tests/perf/k6/soak.js
+++ b/tests/perf/k6/soak.js
@@ -12,6 +12,11 @@ export const options = {
 
 export default function () {
   const base = __ENV.PRISM_API_BASE || 'http://localhost';
-  http.get(`${base}/api/tasks`);
+  const bearer = __ENV.TEST_BEARER;
+  const headers = {};
+  if (bearer) {
+    headers.Authorization = `Bearer ${bearer}`;
+  }
+  http.get(`${base}/api/tasks`, { headers });
 }
 


### PR DESCRIPTION
## Summary
- use `TEST_BEARER` token when calling API in k6 performance tests

## Testing
- `PRISM_API_BASE=http://localhost:8000 TEST_BEARER=token k6 run --vus 1 --duration 1s tests/perf/k6/api_mixed_read_write.js`


------
https://chatgpt.com/codex/tasks/task_e_68c122c869b883339b8b683ea847986d