### PR TITLE
docs: add event catalog

### DIFF
--- a/docs/event_flow.md
+++ b/docs/event_flow.md
@@ -36,3 +36,7 @@ flowchart LR
     SS --> UI
     API --> UI
 ```
+
+## Event Catalog
+
+For a complete list of domain events and their payload structures, see [events.md](./events.md).

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,31 @@
+# Domain Event Catalog
+
+This catalog lists all domain events emitted within the system along with their payload structures.
+
+```mermaid
+flowchart LR
+    subgraph Task Events
+        TC[task-created]
+        TU[task-updated]
+        TCOMP[task-completed]
+    end
+    subgraph User Events
+        UC[user-created]
+        ULIN[user-logged-in]
+        ULO[user-logged-out]
+        USC[user-settings-created]
+        USU[user-settings-updated]
+    end
+```
+
+| Event | Description | Payload Structure |
+|-------|-------------|------------------|
+| `task-created` | New task is created. | `{ "title": string, "notes": string, "category": string, "order": number }` |
+| `task-updated` | Task fields are updated. | `{ "title"?: string, "notes"?: string, "category"?: string, "order"?: number, "done"?: boolean }` |
+| `task-completed` | Task marked as completed. | _No payload_ |
+| `user-created` | New user registered. | `{ "name": string, "email": string }` |
+| `user-logged-in` | User logged in. | _No payload_ |
+| `user-logged-out` | User logged out. | _No payload_ |
+| `user-settings-created` | Initial settings created for user. | `{ "tasksPerCategory": number, "showDoneTasks": boolean }` |
+| `user-settings-updated` | User changed their settings. | `{ "tasksPerCategory"?: number, "showDoneTasks"?: boolean }` |
+


### PR DESCRIPTION
## Summary
- document all domain events with payload structures
- cross-reference the new catalog from event flow documentation

## Testing
- no tests were run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68c5321a177483339edf7c20834eb8a2