### PR TITLE
docs: add command catalog

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,26 @@
+# Domain Command Catalog
+
+This catalog lists all domain commands accepted by the system along with their expected payload structures.
+
+```mermaid
+flowchart LR
+    subgraph Task Commands
+        CTC[create-task]
+        UTC[update-task]
+        CMTC[complete-task]
+    end
+    subgraph User Commands
+        LUC[login-user]
+        LOC[logout-user]
+        UUS[update-user-settings]
+    end
+```
+
+| Command | Description | Payload Structure |
+|---------|-------------|------------------|
+| `create-task` | Create a new task. | `{ "title": string, "notes"?: string, "category"?: string, "order"?: number }` |
+| `update-task` | Modify task fields. | `{ "id": string, "title"?: string, "notes"?: string, "category"?: string, "order"?: number, "done"?: boolean }` |
+| `complete-task` | Mark a task as completed. | `{ "id": string }` |
+| `login-user` | Log a user in, creating the user if they do not exist. | `{ "name": string, "email": string }` |
+| `logout-user` | Log a user out. | _No payload_ |
+| `update-user-settings` | Change user settings. | `{ "tasksPerCategory"?: number, "showDoneTasks"?: boolean }` |

--- a/docs/event_flow.md
+++ b/docs/event_flow.md
@@ -37,6 +37,10 @@ flowchart LR
     API --> UI
 ```
 
+## Command Catalog
+
+For a complete list of domain commands and their payload structures, see [commands.md](./commands.md).
+
 ## Event Catalog
 
 For a complete list of domain events and their payload structures, see [events.md](./events.md).


### PR DESCRIPTION
## Summary
- document domain commands and their payloads
- reference command catalog from event flow guide

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c5521dae748333ae7380c1ef4ba532