### PR TITLE
Add bounded worker pool for command queue

### DIFF
--- a/prism-api/api/handlers.go
+++ b/prism-api/api/handlers.go
@@ -126,7 +126,7 @@ func postCommands(store Storage, auth Authenticator, deduper Deduper) echo.Handl
 			filtered = append(filtered, cmds[i])
 		}
 		if len(filtered) == 0 {
-			return c.JSON(http.StatusOK, postCommandResponse{IdempotencyKeys: keys})
+			return c.JSON(http.StatusAccepted, postCommandResponse{IdempotencyKeys: keys})
 		}
 		if err := store.EnqueueCommands(ctx, userID, filtered); err != nil {
 			for _, key := range added {
@@ -137,6 +137,6 @@ func postCommands(store Storage, auth Authenticator, deduper Deduper) echo.Handl
 			c.Logger().Error(err)
 			return c.JSON(http.StatusInternalServerError, postCommandResponse{IdempotencyKeys: keys, Error: err.Error()})
 		}
-		return c.JSON(http.StatusOK, postCommandResponse{IdempotencyKeys: keys})
+		return c.JSON(http.StatusAccepted, postCommandResponse{IdempotencyKeys: keys})
 	}
 }

--- a/prism-api/api/handlers_test.go
+++ b/prism-api/api/handlers_test.go
@@ -316,8 +316,8 @@ func TestPostCommandsCleansUpOnDeduperError(t *testing.T) {
 	if err := handler(c2); err != nil {
 		t.Fatalf("second post: %v", err)
 	}
-	if rec2.Code != http.StatusOK {
-		t.Fatalf("expected status 200 got %d", rec2.Code)
+	if rec2.Code != http.StatusAccepted {
+		t.Fatalf("expected status 202 got %d", rec2.Code)
 	}
 	if len(d.keys) != 2 {
 		t.Fatalf("expected 2 keys added, got %d", len(d.keys))

--- a/prism-api/main.go
+++ b/prism-api/main.go
@@ -29,7 +29,13 @@ func main() {
 	if connStr == "" || tasksTableName == "" || settingsTableName == "" || commandQueueName == "" {
 		log.Fatal("missing storage config")
 	}
-	store, err := storage.New(connStr, tasksTableName, settingsTableName, commandQueueName)
+	concurrency := 32
+	if v := os.Getenv("COMMAND_SENDER_CONCURRENCY"); v != "" {
+		if c, err := strconv.Atoi(v); err == nil && c > 0 {
+			concurrency = c
+		}
+	}
+	store, err := storage.New(connStr, tasksTableName, settingsTableName, commandQueueName, concurrency)
 	if err != nil {
 		log.Fatalf("storage: %v", err)
 	}

--- a/prism-api/storage/storage.go
+++ b/prism-api/storage/storage.go
@@ -15,10 +15,17 @@ type Storage struct {
 	taskTable     *aztables.Client
 	settingsTable *aztables.Client
 	commandQueue  *azqueue.QueueClient
+	jobs          chan queueJob
+}
+
+type queueJob struct {
+	ctx     context.Context
+	message string
+	result  chan error
 }
 
 // New creates a Storage instance from the given connection string.
-func New(connStr, tasksTable, settingsTable, commandQueue string) (*Storage, error) {
+func New(connStr, tasksTable, settingsTable, commandQueue string, concurrency int) (*Storage, error) {
 	svc, err := aztables.NewServiceClientFromConnectionString(connStr, nil)
 	if err != nil {
 		return nil, err
@@ -29,7 +36,23 @@ func New(connStr, tasksTable, settingsTable, commandQueue string) (*Storage, err
 	if err != nil {
 		return nil, err
 	}
-	return &Storage{taskTable: tt, settingsTable: st, commandQueue: cq}, nil
+	s := &Storage{
+		taskTable:     tt,
+		settingsTable: st,
+		commandQueue:  cq,
+		jobs:          make(chan queueJob, concurrency),
+	}
+	for i := 0; i < concurrency; i++ {
+		go s.worker()
+	}
+	return s, nil
+}
+
+func (s *Storage) worker() {
+	for job := range s.jobs {
+		_, err := s.commandQueue.EnqueueMessage(job.ctx, job.message, nil)
+		job.result <- err
+	}
 }
 
 type taskEntity struct {
@@ -90,13 +113,19 @@ func (s *Storage) FetchSettings(ctx context.Context, userID string) (domain.Sett
 
 // EnqueueCommands sends the given commands to the command queue.
 func (s *Storage) EnqueueCommands(ctx context.Context, userID string, cmds []domain.Command) error {
+	results := make([]chan error, 0, len(cmds))
 	for _, cmd := range cmds {
 		env := domain.CommandEnvelope{UserID: userID, Command: cmd}
 		data, err := json.Marshal(env)
 		if err != nil {
 			return err
 		}
-		if _, err := s.commandQueue.EnqueueMessage(ctx, string(data), nil); err != nil {
+		resCh := make(chan error, 1)
+		s.jobs <- queueJob{ctx: ctx, message: string(data), result: resCh}
+		results = append(results, resCh)
+	}
+	for _, ch := range results {
+		if err := <-ch; err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- throttle command queue writes with a fixed worker pool using `COMMAND_SENDER_CONCURRENCY`
- return 202 Accepted when commands are enqueued
- plumb worker pool configuration through storage initialization

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c5519ee83883339fffb7ec79d852bf