### PR TITLE
Improve task event status retrieval

### DIFF
--- a/domain-service/src/DomainService.Domain/CommandHandlers/CompleteTask.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/CompleteTask.cs
@@ -11,9 +11,8 @@ internal sealed class CompleteTask(ITaskEventRepository taskRepo, IEventQueue ev
 
     public async Task<Unit> Handle(CompleteTaskCommand request, CancellationToken ct)
     {
-        var events = await _taskRepo.Get(request.TaskId, ct);
-        var state = TaskStateBuilder.From(events);
-        if (state.Title == null || state.Done) return Unit.Value;
+        var status = await _taskRepo.GetStatus(request.TaskId, ct);
+        if (!status.Exists || status.Done) return Unit.Value;
 
         var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Completed, null, request.Timestamp, request.UserId, request.IdempotencyKey);
         await _taskRepo.Add(ev, ct);

--- a/domain-service/src/DomainService.Domain/CommandHandlers/ReopenTask.cs
+++ b/domain-service/src/DomainService.Domain/CommandHandlers/ReopenTask.cs
@@ -11,9 +11,8 @@ internal sealed class ReopenTask(ITaskEventRepository taskRepo, IEventQueue even
 
     public async Task<Unit> Handle(ReopenTaskCommand request, CancellationToken ct)
     {
-        var events = await _taskRepo.Get(request.TaskId, ct);
-        var state = TaskStateBuilder.From(events);
-        if (state.Title == null || !state.Done) return Unit.Value;
+        var status = await _taskRepo.GetStatus(request.TaskId, ct);
+        if (!status.Exists || !status.Done) return Unit.Value;
 
         var ev = new Event(Guid.NewGuid().ToString(), request.TaskId, EntityTypes.Task, TaskEventTypes.Reopened, null, request.Timestamp, request.UserId, request.IdempotencyKey);
         await _taskRepo.Add(ev, ct);

--- a/domain-service/src/DomainService.Domain/TaskState.cs
+++ b/domain-service/src/DomainService.Domain/TaskState.cs
@@ -28,16 +28,20 @@ internal static class TaskStateBuilder
         switch (ev.Type)
         {
             case TaskEventTypes.Created:
-                if (ev.Data.HasValue) {
+                if (ev.Data.HasValue)
+                {
                     var data = ev.Data.Value;
                     state.Title = data.GetProperty("title").GetString();
-                    if (data.TryGetProperty("notes", out var n)) {
+                    if (data.TryGetProperty("notes", out var n))
+                    {
                         state.Notes = n.GetString();
                     }
-                    if (data.TryGetProperty("category", out var c)) {
+                    if (data.TryGetProperty("category", out var c))
+                    {
                         state.Category = c.GetString();
                     }
-                    if (data.TryGetProperty("order", out var o) && o.TryGetInt32(out var oi)) {
+                    if (data.TryGetProperty("order", out var o) && o.TryGetInt32(out var oi))
+                    {
                         state.Order = oi;
                     }
                 }
@@ -46,19 +50,24 @@ internal static class TaskStateBuilder
                 if (ev.Data.HasValue)
                 {
                     var data = ev.Data.Value;
-                    if (data.TryGetProperty("title", out var t)) { 
-                        state.Title = t.GetString(); 
+                    if (data.TryGetProperty("title", out var t))
+                    {
+                        state.Title = t.GetString();
                     }
-                    if (data.TryGetProperty("notes", out var n)) {
+                    if (data.TryGetProperty("notes", out var n))
+                    {
                         state.Notes = n.GetString();
                     }
-                    if (data.TryGetProperty("category", out var c)) {
+                    if (data.TryGetProperty("category", out var c))
+                    {
                         state.Category = c.GetString();
                     }
-                    if (data.TryGetProperty("order", out var o) && o.TryGetInt32(out var oi)) {
+                    if (data.TryGetProperty("order", out var o) && o.TryGetInt32(out var oi))
+                    {
                         state.Order = oi;
                     }
-                    if (data.TryGetProperty("done", out var d)) {
+                    if (data.TryGetProperty("done", out var d))
+                    {
                         state.Done = d.ValueKind == System.Text.Json.JsonValueKind.True;
                     }
                 }

--- a/domain-service/src/DomainService.FunctionApp/CommandQueueFunction.cs
+++ b/domain-service/src/DomainService.FunctionApp/CommandQueueFunction.cs
@@ -17,9 +17,11 @@ internal sealed class CommandQueueFunction(ISender sender, ILoggerFactory logger
         try
         {
             var command = _commandFactory.Create(msg);
-            if (command != null) {
+            if (command != null)
+            {
                 await _sender.Send(command, context.CancellationToken);
-            } else
+            }
+            else
             {
                 _logger.LogDebug("Unable to create command from message: {msg}", msg);
             }

--- a/domain-service/src/DomainService.FunctionApp/Repositories/TableTaskEventRepository.cs
+++ b/domain-service/src/DomainService.FunctionApp/Repositories/TableTaskEventRepository.cs
@@ -1,11 +1,13 @@
 using Azure.Data.Tables;
 using DomainService.Interfaces;
+using System.Globalization;
 using System.Text.Json;
 
 namespace DomainService.Repositories;
 
 internal sealed class TableTaskEventRepository(TableClient table) : ITaskEventRepository
 {
+    private static readonly string[] StatusColumns = new[] { "Type", "EventTimestamp", "Data" };
     private readonly TableClient _table = table;
 
     public async Task<IReadOnlyList<IEvent>> Get(string taskId, CancellationToken ct)
@@ -23,11 +25,45 @@ internal sealed class TableTaskEventRepository(TableClient table) : ITaskEventRe
         return [.. list.OrderBy(e => e.Timestamp)];
     }
 
+    public async Task<TaskEventStatus> GetStatus(string taskId, CancellationToken ct)
+    {
+        var filter = $"PartitionKey eq '{taskId}'";
+        var exists = false;
+        var hasStatusEvent = false;
+        var latestTimestamp = long.MinValue;
+        var done = false;
+
+        await foreach (var entity in _table.QueryAsync<TableEntity>(filter: filter, select: StatusColumns, cancellationToken: ct))
+        {
+            exists = true;
+            if (!TryReadEventMetadata(entity, out var eventType, out var timestamp))
+            {
+                continue;
+            }
+
+            if (eventType != TaskEventTypes.Completed && eventType != TaskEventTypes.Reopened)
+            {
+                continue;
+            }
+
+            if (!hasStatusEvent || timestamp > latestTimestamp)
+            {
+                latestTimestamp = timestamp;
+                done = eventType == TaskEventTypes.Completed;
+                hasStatusEvent = true;
+            }
+        }
+
+        return new TaskEventStatus(exists, hasStatusEvent && done);
+    }
+
     public async Task Add(IEvent ev, CancellationToken ct)
     {
         var entity = new TableEntity(ev.EntityId, ev.Id)
         {
             {"UserId", ev.UserId},
+            {"Type", ev.Type},
+            {"EventTimestamp", ev.Timestamp},
             {"Data", JsonSerializer.Serialize(ev)},
             {"IdempotencyKey", ev.IdempotencyKey}
         };
@@ -42,5 +78,88 @@ internal sealed class TableTaskEventRepository(TableClient table) : ITaskEventRe
             return true;
         }
         return false;
+    }
+
+    private static bool TryReadEventMetadata(TableEntity entity, out string eventType, out long timestamp)
+    {
+        eventType = string.Empty;
+        timestamp = default;
+
+        string? resolvedType = null;
+        long? resolvedTimestamp = null;
+
+        if (entity.TryGetValue("Type", out var typeValue) && typeValue is string type && !string.IsNullOrEmpty(type))
+        {
+            resolvedType = type;
+        }
+
+        if (entity.TryGetValue("EventTimestamp", out var timestampValue) && TryConvertTimestamp(timestampValue, out var ts))
+        {
+            resolvedTimestamp = ts;
+        }
+
+        if (resolvedType is not null && resolvedTimestamp is not null)
+        {
+            eventType = resolvedType;
+            timestamp = resolvedTimestamp.Value;
+            return true;
+        }
+
+        if (!entity.TryGetValue("Data", out var dataValue) || dataValue is not string payload || string.IsNullOrEmpty(payload))
+        {
+            if (resolvedType is not null && resolvedTimestamp is not null)
+            {
+                eventType = resolvedType;
+                timestamp = resolvedTimestamp.Value;
+                return true;
+            }
+
+            return false;
+        }
+
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+
+        if (resolvedType is null && root.TryGetProperty(nameof(Event.Type), out var typeProperty) && typeProperty.ValueKind == JsonValueKind.String)
+        {
+            var parsedType = typeProperty.GetString();
+            if (!string.IsNullOrEmpty(parsedType))
+            {
+                resolvedType = parsedType;
+            }
+        }
+
+        if (resolvedTimestamp is null && root.TryGetProperty(nameof(Event.Timestamp), out var timestampProperty) && timestampProperty.TryGetInt64(out var parsedTimestamp))
+        {
+            resolvedTimestamp = parsedTimestamp;
+        }
+
+        if (resolvedType is not null && resolvedTimestamp is not null)
+        {
+            eventType = resolvedType;
+            timestamp = resolvedTimestamp.Value;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryConvertTimestamp(object value, out long timestamp)
+    {
+        switch (value)
+        {
+            case long longValue:
+                timestamp = longValue;
+                return true;
+            case int intValue:
+                timestamp = intValue;
+                return true;
+            case string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed):
+                timestamp = parsed;
+                return true;
+            default:
+                timestamp = default;
+                return false;
+        }
     }
 }

--- a/domain-service/src/DomainService.Interfaces/ITaskEventRepository.cs
+++ b/domain-service/src/DomainService.Interfaces/ITaskEventRepository.cs
@@ -3,6 +3,7 @@ namespace DomainService.Interfaces;
 public interface ITaskEventRepository
 {
     Task<IReadOnlyList<IEvent>> Get(string taskId, CancellationToken ct);
+    Task<TaskEventStatus> GetStatus(string taskId, CancellationToken ct);
     Task Add(IEvent ev, CancellationToken ct);
     Task<bool> Exists(string idempotencyKey, CancellationToken ct);
 }

--- a/domain-service/src/DomainService.Interfaces/TaskEventStatus.cs
+++ b/domain-service/src/DomainService.Interfaces/TaskEventStatus.cs
@@ -1,0 +1,15 @@
+namespace DomainService.Interfaces;
+
+public readonly struct TaskEventStatus
+{
+    public static TaskEventStatus NotFound => default;
+
+    public TaskEventStatus(bool exists, bool done)
+    {
+        Exists = exists;
+        Done = done;
+    }
+
+    public bool Exists { get; }
+    public bool Done { get; }
+}


### PR DESCRIPTION
## Summary
- add a TaskEventStatus value type for repository status responses
- update the table-backed repository to store lightweight metadata and determine the latest task status without replaying every event
- align the in-memory repository and tests with the new status contract

## Testing
- dotnet format domain-service/DomainService.sln
- dotnet test domain-service/DomainService.sln

------
https://chatgpt.com/codex/tasks/task_e_68c963f00b90833390d7e359e7538b5f