### PR TITLE
Add explicit task ordering controls

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,3 +26,14 @@ flowchart LR
 | `login-user` | Log a user in, creating the user if they do not exist. | `{ "name": string, "email": string }` |
 | `logout-user` | Log a user out. | _No payload_ |
 | `update-user-settings` | Change user settings. | `{ "tasksPerCategory"?: number, "showDoneTasks"?: boolean }` |
+
+## Task ordering semantics
+
+Tasks within the same category are ordered using the zero-based `order` attribute. The frontend now exposes explicit "move up"
+and "move down" controls on each task card. Activating either control generates two `update-task` commands: one for the
+selected task and one for the adjacent task that swaps places. Each command updates only the `order` field, which keeps the
+ordering logic isolated and idempotent.
+
+Dragging a task between categories issues a single `update-task` command that changes the `category` and assigns an `order`
+value equal to the number of existing tasks in the target category. This guarantees that the moved task is appended to the end
+of the destination category while keeping intra-category drag and drop disabled.

--- a/docs/events.md
+++ b/docs/events.md
@@ -47,3 +47,10 @@ Task and user events are stored in dedicated Azure Table Storage tables. Each ro
 
 All persisted string and integer columns include explicit `@odata.type` annotations so downstream services can rely on consistent typing when reading the tables.
 
+### Task ordering updates
+
+Reordering uses `task-updated` events that include only the `order` field for the affected tasks. When a task is moved to
+another category, the emitted `task-updated` event carries both the new `category` and an `order` value equal to the number of
+tasks that existed in the destination category prior to the move. This ensures downstream consumers append the task instead of
+reordering existing items.
+

--- a/frontend/src/components/Board/Board.test.tsx
+++ b/frontend/src/components/Board/Board.test.tsx
@@ -60,6 +60,38 @@ describe('Board', () => {
     });
   });
 
+  it('appends moved task to end of destination category', () => {
+    const tasks: Task[] = [
+      { id: '1', title: 'Task A', category: 'normal', order: 0 },
+      { id: '2', title: 'Task B', category: 'normal', order: 1 },
+      { id: '3', title: 'Task C', category: 'fun', order: 0 },
+    ];
+    const updateTask = vi.fn();
+    const ev: any = {
+      active: { id: '3' },
+      over: { id: '1', data: { current: { category: 'normal' } } }
+    };
+    handleDragEnd(ev, tasks, updateTask, vi.fn());
+    expect(updateTask).toHaveBeenCalledWith('3', {
+      category: 'normal',
+      order: 2,
+    });
+  });
+
+  it('ignores drag and drop within the same category', () => {
+    const tasks: Task[] = [
+      { id: '1', title: 'Task A', category: 'normal', order: 0 },
+      { id: '2', title: 'Task B', category: 'normal', order: 1 },
+    ];
+    const updateTask = vi.fn();
+    const ev: any = {
+      active: { id: '1' },
+      over: { id: '2', data: { current: { category: 'normal' } } }
+    };
+    handleDragEnd(ev, tasks, updateTask, vi.fn());
+    expect(updateTask).not.toHaveBeenCalled();
+  });
+
   it('reopens task on double click in done lane', () => {
     vi.useFakeTimers();
     const tasks: Task[] = [
@@ -82,6 +114,29 @@ describe('Board', () => {
     vi.runAllTimers();
     expect(reopenTask).toHaveBeenCalledWith('1');
     vi.useRealTimers();
+  });
+
+  it('uses arrow controls to swap tasks within a lane', () => {
+    const tasks: Task[] = [
+      { id: '1', title: 'First', category: 'normal', order: 0 },
+      { id: '2', title: 'Second', category: 'normal', order: 1 },
+      { id: '3', title: 'Third', category: 'normal', order: 2 }
+    ];
+    const updateTask = vi.fn();
+    render(
+      <Board
+        tasks={tasks}
+        settings={{ tasksPerCategory: 5, showDoneTasks: false }}
+        updateTask={updateTask}
+        completeTask={() => {}}
+        reopenTask={() => {}}
+      />
+    );
+    const moveDown = screen.getByRole('button', { name: 'Move First down' });
+    fireEvent.click(moveDown);
+    expect(updateTask).toHaveBeenCalledTimes(2);
+    expect(updateTask).toHaveBeenNthCalledWith(1, '1', { order: 1 });
+    expect(updateTask).toHaveBeenNthCalledWith(2, '2', { order: 0 });
   });
 });
 

--- a/frontend/src/components/Board/Board.test.tsx
+++ b/frontend/src/components/Board/Board.test.tsx
@@ -78,6 +78,24 @@ describe('Board', () => {
     });
   });
 
+  it('assigns next order greater than existing values when lane has gaps', () => {
+    const tasks: Task[] = [
+      { id: '1', title: 'Task A', category: 'normal', order: 0 },
+      { id: '2', title: 'Task B', category: 'normal', order: 2 },
+      { id: '3', title: 'Task C', category: 'fun', order: 0 },
+    ];
+    const updateTask = vi.fn();
+    const ev: any = {
+      active: { id: '3' },
+      over: { id: '1', data: { current: { category: 'normal' } } }
+    };
+    handleDragEnd(ev, tasks, updateTask, vi.fn());
+    expect(updateTask).toHaveBeenCalledWith('3', {
+      category: 'normal',
+      order: 3,
+    });
+  });
+
   it('ignores drag and drop within the same category', () => {
     const tasks: Task[] = [
       { id: '1', title: 'Task A', category: 'normal', order: 0 },

--- a/frontend/src/components/Board/Board.tsx
+++ b/frontend/src/components/Board/Board.tsx
@@ -23,6 +23,10 @@ interface Props {
 
 const categories: Category[] = ['critical', 'fun', 'important', 'normal'];
 
+function getNextOrder(tasks: Task[]) {
+  return tasks.reduce((max, task) => Math.max(max, task.order ?? 0), -1) + 1;
+}
+
 export function handleDragEnd(
   ev: DragEndEvent,
   tasks: Task[],
@@ -52,7 +56,7 @@ export function handleDragEnd(
       return;
     }
     const targetLane = tasks.filter((t) => t.category === toCat && !t.done);
-    const order = targetLane.length;
+    const order = getNextOrder(targetLane);
     updateTask(active.id as string, { category: toCat, order, done: false });
     return;
   }
@@ -60,7 +64,7 @@ export function handleDragEnd(
   if (fromCat !== toCat) {
     // move to another lane; place at end if dropped on lane itself
     const targetLane = tasks.filter((t) => t.category === toCat && !t.done);
-    const order = targetLane.length;
+    const order = getNextOrder(targetLane);
     updateTask(active.id as string, { category: toCat, order });
     return;
   }

--- a/frontend/src/components/TaskCard/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.test.tsx
@@ -63,5 +63,40 @@ describe('TaskCard', () => {
     expect(handleClick).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
+
+  it('renders move controls with accessible labels and triggers callbacks', () => {
+    vi.useFakeTimers();
+    const task: Task = {
+      id: '1',
+      title: 'Sample',
+      category: 'normal',
+      notes: '',
+      order: 0,
+      done: false
+    };
+    const handleMoveUp = vi.fn();
+    const handleMoveDown = vi.fn();
+    const handleClick = vi.fn();
+    render(
+      <TaskCard
+        task={task}
+        onMoveUp={handleMoveUp}
+        onMoveDown={handleMoveDown}
+        onClick={handleClick}
+        showOrderControls
+      />
+    );
+    const upButton = screen.getByRole('button', { name: `Move ${task.title} up` });
+    const downButton = screen.getByRole('button', { name: `Move ${task.title} down` });
+
+    fireEvent.click(upButton);
+    fireEvent.click(downButton);
+    vi.runAllTimers();
+
+    expect(handleMoveUp).toHaveBeenCalledTimes(1);
+    expect(handleMoveDown).toHaveBeenCalledTimes(1);
+    expect(handleClick).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
 });
 

--- a/frontend/src/components/TaskCard/TaskCard.tsx
+++ b/frontend/src/components/TaskCard/TaskCard.tsx
@@ -1,6 +1,7 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useRef } from 'react';
+import type { MouseEvent } from 'react';
 import type { Task } from '../../types';
 import { palette } from '../../palette';
 import { aria } from './aria';
@@ -9,9 +10,19 @@ interface Props {
   task: Task;
   onClick?: () => void;
   onDoubleClick?: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  showOrderControls?: boolean;
 }
 
-export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
+export default function TaskCard({
+  task,
+  onClick,
+  onDoubleClick,
+  onMoveUp,
+  onMoveDown,
+  showOrderControls,
+}: Props) {
   const {
     attributes,
     listeners,
@@ -31,7 +42,19 @@ export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
 
   const clickTimeout = useRef<NodeJS.Timeout | null>(null);
 
-  function handleClick(ev: React.MouseEvent<HTMLDivElement>) {
+  const handleMoveUp = (ev: MouseEvent<HTMLButtonElement>) => {
+    ev.stopPropagation();
+    ev.preventDefault();
+    onMoveUp?.();
+  };
+
+  const handleMoveDown = (ev: MouseEvent<HTMLButtonElement>) => {
+    ev.stopPropagation();
+    ev.preventDefault();
+    onMoveDown?.();
+  };
+
+  function handleClick(ev: MouseEvent<HTMLDivElement>) {
     if (ev.detail === 2) {
       if (clickTimeout.current) {
         clearTimeout(clickTimeout.current);
@@ -57,12 +80,36 @@ export default function TaskCard({ task, onClick, onDoubleClick }: Props) {
       {...attributes}
       {...aria.root(task.title)}
       onClick={handleClick}
-      className="w-full select-none rounded-lg border-l-4 bg-white text-gray-800 shadow transition-shadow touch-none hover:shadow-md cursor-pointer px-1 py-1 text-xs sm:px-4 sm:py-3 sm:text-sm"
+      className="w-full select-none rounded-lg border-l-4 bg-white text-gray-800 shadow transition-shadow touch-none hover:shadow-md cursor-pointer px-1 py-1 text-xs sm:px-4 sm:py-3 sm:text-sm flex items-start justify-between gap-2"
     >
-      <div className="font-medium">{task.title}</div>
-      {task.notes && (
-        <div className="mt-1 text-gray-500 text-[10px] sm:text-xs whitespace-pre-line break-words overflow-hidden text-ellipsis task-card-note">
-          {task.notes}
+      <div className="min-w-0 flex-1">
+        <div className="font-medium break-words">{task.title}</div>
+        {task.notes && (
+          <div className="mt-1 whitespace-pre-line break-words text-[10px] text-gray-500 sm:text-xs overflow-hidden text-ellipsis task-card-note">
+            {task.notes}
+          </div>
+        )}
+      </div>
+      {showOrderControls && (
+        <div className="ml-1 flex flex-col items-center gap-1 sm:ml-2">
+          <button
+            type="button"
+            onClick={handleMoveUp}
+            disabled={!onMoveUp}
+            aria-label={`Move ${task.title} up`}
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-transparent bg-gray-100 text-lg text-gray-600 transition hover:bg-gray-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:w-7"
+          >
+            <span aria-hidden="true">↑</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleMoveDown}
+            disabled={!onMoveDown}
+            aria-label={`Move ${task.title} down`}
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-transparent bg-gray-100 text-lg text-gray-600 transition hover:bg-gray-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:w-7"
+          >
+            <span aria-hidden="true">↓</span>
+          </button>
         </div>
       )}
     </div>

--- a/frontend/src/components/UserMenu/UserMenu.test.tsx
+++ b/frontend/src/components/UserMenu/UserMenu.test.tsx
@@ -1,6 +1,26 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import UserMenu, { aria } from '.';
+
+vi.mock('@headlessui/react', () => {
+  const Menu = ({ children }: any) => <div>{children}</div>;
+  Menu.Button = ({ children, ...props }: any) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  );
+  Menu.Items = ({ children }: any) => <div>{children}</div>;
+  Menu.Item = ({ children }: any) => <div>{typeof children === 'function' ? children({ active: false }) : children}</div>;
+  return {
+    Menu,
+    Transition: ({ children }: any) => <>{children}</>,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe('UserMenu', () => {
   it('calls onLogin when login icon clicked', () => {
@@ -15,5 +35,50 @@ describe('UserMenu', () => {
   it('renders avatar when authenticated', () => {
     render(<UserMenu isAuthenticated userPicture="pic" onLogin={() => {}} onLogout={() => {}} />);
     expect(screen.getByAltText(aria.avatar.alt)).toBeTruthy();
+  });
+
+  it('throttles tasks per category updates while typing', () => {
+    vi.useFakeTimers();
+    const onUpdateSettings = vi.fn();
+    render(
+      <UserMenu
+        isAuthenticated
+        userPicture="pic"
+        onLogin={() => {}}
+        onLogout={() => {}}
+        settings={{ tasksPerCategory: 3, showDoneTasks: false }}
+        onUpdateSettings={onUpdateSettings}
+      />
+    );
+    const input = screen.getByLabelText('Tasks per category');
+    fireEvent.change(input, { target: { value: '4' } });
+    vi.advanceTimersByTime(300);
+    expect(onUpdateSettings).not.toHaveBeenCalled();
+    fireEvent.change(input, { target: { value: '5' } });
+    vi.advanceTimersByTime(399);
+    expect(onUpdateSettings).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onUpdateSettings).toHaveBeenCalledTimes(1);
+    expect(onUpdateSettings).toHaveBeenCalledWith({ tasksPerCategory: 5 });
+  });
+
+  it('flushes pending update on blur', () => {
+    vi.useFakeTimers();
+    const onUpdateSettings = vi.fn();
+    render(
+      <UserMenu
+        isAuthenticated
+        userPicture="pic"
+        onLogin={() => {}}
+        onLogout={() => {}}
+        settings={{ tasksPerCategory: 3, showDoneTasks: false }}
+        onUpdateSettings={onUpdateSettings}
+      />
+    );
+    const input = screen.getByLabelText('Tasks per category');
+    fireEvent.change(input, { target: { value: '6' } });
+    fireEvent.blur(input);
+    expect(onUpdateSettings).toHaveBeenCalledTimes(1);
+    expect(onUpdateSettings).toHaveBeenCalledWith({ tasksPerCategory: 6 });
   });
 });

--- a/frontend/src/components/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/UserMenu/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo } from 'react';
+import { Fragment, memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { UserCircleIcon } from '@heroicons/react/24/solid';
 import { aria } from './aria';
@@ -13,7 +13,87 @@ interface UserMenuProps {
   onUpdateSettings?: (changes: Partial<Settings>) => void;
 }
 
+const TASKS_PER_CATEGORY_DEBOUNCE_MS = 400;
+
 function UserMenu({ isAuthenticated, userPicture, onLogin, onLogout, settings, onUpdateSettings }: UserMenuProps) {
+  const [tasksPerCategoryInput, setTasksPerCategoryInput] = useState(
+    () => `${settings?.tasksPerCategory ?? 3}`
+  );
+  const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const pendingTasksPerCategoryRef = useRef<number | null>(null);
+  const updateSettingsRef = useRef(onUpdateSettings);
+
+  useEffect(() => {
+    updateSettingsRef.current = onUpdateSettings;
+  }, [onUpdateSettings]);
+
+  const currentTasksPerCategory = settings?.tasksPerCategory ?? 3;
+
+  useEffect(() => {
+    setTasksPerCategoryInput((current) => {
+      const parsed = Number.parseInt(current, 10);
+      const normalized = Number.isNaN(parsed) ? currentTasksPerCategory : parsed;
+      if (normalized === currentTasksPerCategory) {
+        return `${currentTasksPerCategory}`;
+      }
+      return current;
+    });
+  }, [currentTasksPerCategory]);
+
+  useEffect(() => () => {
+    if (updateTimeoutRef.current) {
+      clearTimeout(updateTimeoutRef.current);
+    }
+  }, []);
+
+  const scheduleTasksPerCategoryUpdate = useCallback((next: number) => {
+    pendingTasksPerCategoryRef.current = next;
+    if (!updateSettingsRef.current) {
+      return;
+    }
+    if (updateTimeoutRef.current) {
+      clearTimeout(updateTimeoutRef.current);
+    }
+    updateTimeoutRef.current = setTimeout(() => {
+      updateTimeoutRef.current = null;
+      const value = pendingTasksPerCategoryRef.current;
+      if (typeof value === 'number') {
+        pendingTasksPerCategoryRef.current = null;
+        updateSettingsRef.current?.({ tasksPerCategory: value });
+      }
+    }, TASKS_PER_CATEGORY_DEBOUNCE_MS);
+  }, []);
+
+  const flushPendingTasksPerCategoryUpdate = useCallback(() => {
+    if (updateTimeoutRef.current) {
+      clearTimeout(updateTimeoutRef.current);
+      updateTimeoutRef.current = null;
+    }
+    const value = pendingTasksPerCategoryRef.current;
+    if (typeof value === 'number') {
+      pendingTasksPerCategoryRef.current = null;
+      updateSettingsRef.current?.({ tasksPerCategory: value });
+    }
+  }, []);
+
+  const handleTasksPerCategoryChange = useCallback(
+    (value: string) => {
+      setTasksPerCategoryInput(value);
+      const parsed = Number.parseInt(value, 10);
+      const normalized = Number.isNaN(parsed) ? 0 : parsed;
+      if (normalized === currentTasksPerCategory) {
+        if (updateTimeoutRef.current) {
+          clearTimeout(updateTimeoutRef.current);
+          updateTimeoutRef.current = null;
+        }
+        pendingTasksPerCategoryRef.current = null;
+        return;
+      }
+      scheduleTasksPerCategoryUpdate(normalized);
+    },
+    [currentTasksPerCategory, scheduleTasksPerCategoryUpdate]
+  );
+
   return (
     <div className="flex items-center">
       {isAuthenticated ? (
@@ -37,10 +117,9 @@ function UserMenu({ isAuthenticated, userPicture, onLogin, onLogout, settings, o
                   <input
                     type="number"
                     min={1}
-                    value={settings?.tasksPerCategory ?? 3}
-                    onChange={(e) =>
-                      onUpdateSettings?.({ tasksPerCategory: parseInt(e.target.value, 10) || 0 })
-                    }
+                    value={tasksPerCategoryInput}
+                    onChange={(e) => handleTasksPerCategoryChange(e.target.value)}
+                    onBlur={flushPendingTasksPerCategoryUpdate}
                     className="mt-1 w-full rounded border border-gray-300 px-1 py-0.5 text-xs"
                   />
                 </label>

--- a/prism-api/domain/task.go
+++ b/prism-api/domain/task.go
@@ -2,10 +2,10 @@ package domain
 
 // Task represents a single board item in the read model.
 type Task struct {
-	ID       string `json:"id"`
-	Title    string `json:"title"`
-	Notes    string `json:"notes,omitempty"`
-	Category string `json:"category"`
-	Order    int    `json:"order,omitempty"`
-	Done     bool   `json:"done,omitempty"`
+        ID       string `json:"id"`
+        Title    string `json:"title"`
+        Notes    string `json:"notes,omitempty"`
+        Category string `json:"category"`
+        Order    int    `json:"order"`
+        Done     bool   `json:"done,omitempty"`
 }

--- a/prism-api/domain/task_test.go
+++ b/prism-api/domain/task_test.go
@@ -1,0 +1,20 @@
+package domain
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTaskMarshalIncludesZeroOrder(t *testing.T) {
+	task := Task{ID: "t1", Title: "Title", Category: "normal", Order: 0}
+
+	payload, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("marshal task: %v", err)
+	}
+
+	if !strings.Contains(string(payload), "\"order\":0") {
+		t.Fatalf("expected order field to be present, got %s", payload)
+	}
+}

--- a/stream-service/domain/task.go
+++ b/stream-service/domain/task.go
@@ -1,12 +1,12 @@
 package domain
 
 type Task struct {
-	ID       string `json:"id"`
-	Title    string `json:"title,omitempty"`
-	Notes    string `json:"notes,omitempty"`
-	Category string `json:"category,omitempty"`
-	Order    int    `json:"order,omitempty"`
-	Done     *bool  `json:"done,omitempty"`
+        ID       string `json:"id"`
+        Title    string `json:"title,omitempty"`
+        Notes    string `json:"notes,omitempty"`
+        Category string `json:"category,omitempty"`
+        Order    int    `json:"order"`
+        Done     *bool  `json:"done,omitempty"`
 }
 
 type UserSettings struct {

--- a/stream-service/domain/task_test.go
+++ b/stream-service/domain/task_test.go
@@ -1,0 +1,20 @@
+package domain
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTaskMarshalIncludesZeroOrder(t *testing.T) {
+	task := Task{ID: "t1", Title: "Test", Category: "normal", Order: 0}
+
+	payload, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("marshal task: %v", err)
+	}
+
+	if !strings.Contains(string(payload), "\"order\":0") {
+		t.Fatalf("expected order field to be present, got %s", payload)
+	}
+}

--- a/tests/integration/scenarios/helpers_test.go
+++ b/tests/integration/scenarios/helpers_test.go
@@ -23,6 +23,7 @@ type task struct {
 	Notes    string `json:"notes"`
 	Done     bool   `json:"done"`
 	Category string `json:"category"`
+	Order    int    `json:"order"`
 }
 
 func getPollTimeout(t *testing.T) time.Duration {

--- a/tests/integration/scenarios/task_order_controls_test.go
+++ b/tests/integration/scenarios/task_order_controls_test.go
@@ -1,0 +1,155 @@
+package scenarios
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"prismtest/internal/assertx"
+)
+
+func TestTaskOrderControls(t *testing.T) {
+	client := newPrismApiClient(t)
+	prefix := fmt.Sprintf("order-%d", time.Now().UnixNano())
+
+	create := func(title, category string, idx int) {
+		payload := map[string]any{"title": title, "category": category}
+		key := fmt.Sprintf("ik-%s-create-%d", prefix, idx)
+		if resp, err := client.PostJSON("/api/commands", []command{{
+			IdempotencyKey: key,
+			EntityType:     "task",
+			Type:           "create-task",
+			Data:           payload,
+		}}, nil); err != nil || resp.StatusCode >= 300 {
+			t.Fatalf("create %s: status %d err %v", title, resp.StatusCode, err)
+		}
+	}
+
+	// create three tasks in the normal lane
+	normalTitles := make([]string, 3)
+	for i := 0; i < len(normalTitles); i++ {
+		normalTitles[i] = fmt.Sprintf("%s-normal-%d", prefix, i)
+		create(normalTitles[i], "normal", i)
+	}
+
+	// create two tasks in the fun lane to establish an existing order baseline
+	funTitles := make([]string, 2)
+	for i := 0; i < len(funTitles); i++ {
+		funTitles[i] = fmt.Sprintf("%s-fun-%d", prefix, i)
+		create(funTitles[i], "fun", i+len(normalTitles))
+	}
+
+	var normalIDs [3]string
+
+	pollTasks(t, client, "all seeded tasks to exist", func(ts []task) bool {
+		foundNormal := 0
+		foundFun := 0
+		for _, tk := range ts {
+			if strings.HasPrefix(tk.Title, prefix+"-normal-") {
+				for idx, title := range normalTitles {
+					if tk.Title == title {
+						normalIDs[idx] = tk.ID
+						break
+					}
+				}
+				foundNormal++
+			}
+			if strings.HasPrefix(tk.Title, prefix+"-fun-") {
+				foundFun++
+			}
+		}
+		return foundNormal == len(normalTitles) && foundFun == len(funTitles)
+	})
+
+	for idx, id := range normalIDs {
+		if id == "" {
+			t.Fatalf("missing normal task id at index %d", idx)
+		}
+	}
+
+	// swap the first two normal tasks to emulate the arrow controls
+	reorderKey := fmt.Sprintf("ik-%s-reorder", prefix)
+	commands := []command{
+		{
+			IdempotencyKey: reorderKey + "-up",
+			EntityType:     "task",
+			Type:           "update-task",
+			Data: map[string]any{
+				"id":    normalIDs[0],
+				"order": 1,
+			},
+		},
+		{
+			IdempotencyKey: reorderKey + "-down",
+			EntityType:     "task",
+			Type:           "update-task",
+			Data: map[string]any{
+				"id":    normalIDs[1],
+				"order": 0,
+			},
+		},
+	}
+	if resp, err := client.PostJSON("/api/commands", commands, nil); err != nil || resp.StatusCode >= 300 {
+		t.Fatalf("reorder commands: status %d err %v", resp.StatusCode, err)
+	}
+
+	pollTasks(t, client, "normal tasks swapped", func(ts []task) bool {
+		for _, tk := range ts {
+			if tk.ID == normalIDs[0] && tk.Order != 1 {
+				return false
+			}
+			if tk.ID == normalIDs[1] && tk.Order != 0 {
+				return false
+			}
+		}
+		return true
+	})
+
+	// move the last normal task to the fun lane; it should be appended to the end
+	moveKey := fmt.Sprintf("ik-%s-move", prefix)
+	lastNormalID := normalIDs[2]
+	targetOrder := len(funTitles)
+	if resp, err := client.PostJSON("/api/commands", []command{{
+		IdempotencyKey: moveKey,
+		EntityType:     "task",
+		Type:           "update-task",
+		Data: map[string]any{
+			"id":       lastNormalID,
+			"category": "fun",
+			"order":    targetOrder,
+		},
+	}}, nil); err != nil || resp.StatusCode >= 300 {
+		t.Fatalf("move command: status %d err %v", resp.StatusCode, err)
+	}
+
+	tasks := pollTasks(t, client, "task appended to fun lane", func(ts []task) bool {
+		moved := false
+		for _, tk := range ts {
+			if tk.ID == lastNormalID {
+				moved = tk.Category == "fun" && tk.Order == targetOrder
+				break
+			}
+		}
+		return moved
+	})
+
+	// verify the fun lane ordering is contiguous and the moved task sits at the end
+	var funOrders []int
+	for _, tk := range tasks {
+		if tk.Category == "fun" && strings.HasPrefix(tk.Title, prefix) {
+			funOrders = append(funOrders, tk.Order)
+		}
+	}
+	assertx.Equal(t, len(funTitles)+1, len(funOrders))
+	found := false
+	for _, ord := range funOrders {
+		if ord == targetOrder {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected to find order %d in %v", targetOrder, funOrders)
+	}
+}


### PR DESCRIPTION
## Summary
- disable drag-and-drop reordering within a lane and append moved tasks to the end of the destination category
- add accessible move up/down controls to task cards and route callbacks through lanes and the board
- document the updated ordering semantics and cover them with new unit and integration tests
- throttle tasks-per-category settings updates so commands emit after typing pauses, with unit coverage for the throttled input
- ensure order 0 is serialized in stream-service and prism-api payloads with new regression tests

## Testing
- npm test -- --run
- go test ./stream-service/...
- go test ./prism-api/... *(fails: TestPostCommandsIdempotency expects command infrastructure that isn't available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca83443ff083338098d613a1b13098