### PR TITLE
Fix domain service JSON dependency and add queue fallback integration test

### DIFF
--- a/domain-service/src/DomainService.FunctionApp/DomainService.FunctionApp.csproj
+++ b/domain-service/src/DomainService.FunctionApp/DomainService.FunctionApp.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.23.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DomainService.Domain\DomainService.Domain.csproj" />

--- a/tests/integration/scenarios/fallback_queue_failure_test.go
+++ b/tests/integration/scenarios/fallback_queue_failure_test.go
@@ -1,0 +1,85 @@
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue/queueerror"
+)
+
+func TestCommandQueueFallbackWhenDomainEventsQueueUnavailable(t *testing.T) {
+	connStr := os.Getenv("STORAGE_CONNECTION_STRING_LOCAL")
+	commandQueueName := os.Getenv("COMMAND_QUEUE")
+	domainEventsQueueName := os.Getenv("DOMAIN_EVENTS_QUEUE")
+	if connStr == "" || commandQueueName == "" || domainEventsQueueName == "" {
+		t.Skip("azure storage configuration missing")
+	}
+
+	ctx := context.Background()
+
+	eventsQueue, err := azqueue.NewQueueClientFromConnectionString(connStr, domainEventsQueueName, nil)
+	if err != nil {
+		t.Fatalf("domain events queue client: %v", err)
+	}
+	t.Cleanup(func() {
+		// Restore queue availability for subsequent scenarios.
+		if _, err := eventsQueue.Create(context.Background(), nil); err != nil && !queueerror.HasCode(err, queueerror.QueueAlreadyExists) {
+			t.Fatalf("restore domain events queue: %v", err)
+		}
+	})
+
+	if _, err := eventsQueue.Delete(ctx, nil); err != nil && !queueerror.HasCode(err, queueerror.QueueNotFound, queueerror.QueueBeingDeleted) {
+		t.Fatalf("delete domain events queue: %v", err)
+	}
+
+	commandQueue, err := azqueue.NewQueueClientFromConnectionString(connStr, commandQueueName, nil)
+	if err != nil {
+		t.Fatalf("command queue client: %v", err)
+	}
+
+	title := fmt.Sprintf("fallback-queue-title-%d", time.Now().UnixNano())
+	idempotencyKey := fmt.Sprintf("ik-fallback-%d", time.Now().UnixNano())
+
+	envelope := map[string]any{
+		"userId": "integration-user",
+		"command": map[string]any{
+			"id":             idempotencyKey,
+			"idempotencyKey": idempotencyKey,
+			"entityType":     "task",
+			"type":           "create-task",
+			"timestamp":      time.Now().UnixMilli(),
+			"data": map[string]any{
+				"title": title,
+			},
+		},
+	}
+
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+
+	if _, err := commandQueue.EnqueueMessage(ctx, string(payload), nil); err != nil {
+		t.Fatalf("enqueue command: %v", err)
+	}
+
+	client := newPrismApiClient(t)
+
+	pollTasks(t, client, fmt.Sprintf("task %s to appear via fallback", title), func(ts []task) bool {
+		for _, tk := range ts {
+			if tk.Title == title {
+				return true
+			}
+		}
+		return false
+	})
+
+	if _, err := eventsQueue.GetProperties(ctx, nil); err == nil || !queueerror.HasCode(err, queueerror.QueueNotFound, queueerror.QueueBeingDeleted) {
+		t.Fatalf("domain events queue unexpectedly reachable: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add an explicit System.Text.Json dependency to the domain-service Azure Function to stabilize JsonElement usage during CI builds
- add an integration scenario that drops the domain-events queue, enqueues a command, and confirms the HTTP fallback updates the read model

## Testing
- dotnet publish src/DomainService.FunctionApp/DomainService.FunctionApp.csproj -c Release -o /tmp/out
- dotnet test tests/DomainService.Tests/DomainService.Tests.csproj
- bash tests/scripts/run-integration.sh *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc10ce5ff883338235f522695348c4