### PR TITLE
Enforce Auth0 login before loading app

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import App from './App';
 import { aria } from './aria';
+import { useAuth0 } from '@auth0/auth0-react';
 
 vi.mock('./hooks', () => ({
   useTasks: () => ({
@@ -9,28 +11,69 @@ vi.mock('./hooks', () => ({
     addTask: vi.fn(),
     updateTask: vi.fn(),
     completeTask: vi.fn(),
-    reopenTask: vi.fn()
+    reopenTask: vi.fn(),
   }),
   useLoginUser: () => {},
   useSettings: () => ({
     settings: { tasksPerCategory: 3, showDoneTasks: true },
-    updateSettings: vi.fn()
-  })
+    updateSettings: vi.fn(),
+  }),
 }));
 
 vi.mock('@auth0/auth0-react', () => ({
-  useAuth0: () => ({
-    loginWithRedirect: vi.fn(),
-    logout: vi.fn(),
-    isAuthenticated: false,
-    user: null,
-    getAccessTokenSilently: vi.fn()
-  })
+  useAuth0: vi.fn(),
 }));
 
+const loginWithRedirect = vi.fn();
+const logout = vi.fn();
+const getAccessTokenSilently = vi.fn();
+const mockedUseAuth0 = useAuth0 as unknown as Mock;
+
 describe('App', () => {
-  it('applies aria attributes to header, main and footer', () => {
+  beforeEach(() => {
+    loginWithRedirect.mockReset();
+    logout.mockReset();
+    getAccessTokenSilently.mockReset();
+    mockedUseAuth0.mockReset();
+  });
+
+  it('redirects unauthenticated users to the login page', async () => {
+    mockedUseAuth0.mockReturnValue({
+      loginWithRedirect,
+      logout,
+      isAuthenticated: false,
+      isLoading: false,
+      user: null,
+      getAccessTokenSilently,
+      error: undefined,
+    });
+
     render(<App />);
+
+    await waitFor(() => {
+      expect(loginWithRedirect).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByText(/redirecting to sign in/i)).toBeTruthy();
+    expect(
+      screen.queryByRole('banner', { name: aria.header['aria-label'] })
+    ).toBeNull();
+  });
+
+  it('renders the application layout once authenticated', () => {
+    mockedUseAuth0.mockReturnValue({
+      loginWithRedirect,
+      logout,
+      isAuthenticated: true,
+      isLoading: false,
+      user: { picture: 'avatar.png' },
+      getAccessTokenSilently,
+      error: undefined,
+    });
+
+    render(<App />);
+
+    expect(loginWithRedirect).not.toHaveBeenCalled();
     expect(
       screen.getByRole('banner', { name: aria.header['aria-label'] })
     ).toBeTruthy();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import Board from './components/Board';
 import TaskModal from './components/TaskModal';
@@ -8,12 +8,13 @@ import SearchBar from './components/SearchBar';
 import AddTaskButton from './components/AddTaskButton';
 import { aria } from './aria';
 
-export default function App() {
+function AuthenticatedApp() {
   const { tasks, addTask, updateTask, completeTask, reopenTask } = useTasks();
   const { settings, updateSettings } = useSettings();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const { loginWithRedirect, logout, isAuthenticated, user, getAccessTokenSilently } = useAuth0();
+  const { loginWithRedirect, logout, isAuthenticated, user, getAccessTokenSilently } =
+    useAuth0();
   const baseUrl =
     (import.meta.env.VITE_API_BASE_URL as string | undefined) ||
     `${window.location.origin}/api`;
@@ -88,7 +89,10 @@ export default function App() {
         />
       </main>
 
-      <footer {...aria.footer} className="pt-2 text-center text-[10px] text-gray-500 sm:pt-4 sm:text-xs">
+      <footer
+        {...aria.footer}
+        className="pt-2 text-center text-[10px] text-gray-500 sm:pt-4 sm:text-xs"
+      >
         Copyright © 2025 Vladimir Pavlov. All rights reserved.
       </footer>
 
@@ -99,4 +103,39 @@ export default function App() {
       />
     </div>
   );
+}
+
+export default function App() {
+  const { isAuthenticated, isLoading, loginWithRedirect, error } = useAuth0();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      loginWithRedirect();
+    }
+  }, [isLoading, isAuthenticated, loginWithRedirect]);
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="flex min-h-screen items-center justify-center p-4 text-center text-red-600"
+      >
+        {error.message || 'Authentication failed.'}
+      </div>
+    );
+  }
+
+  if (isLoading || !isAuthenticated) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex min-h-screen items-center justify-center p-4 text-center text-gray-600"
+      >
+        Redirecting to sign in…
+      </div>
+    );
+  }
+
+  return <AuthenticatedApp />;
 }


### PR DESCRIPTION
## Summary
- require successful Auth0 authentication before rendering the board UI and running data hooks
- show a redirect status state and surface authentication errors to the user
- update App tests to cover the redirect flow and authenticated rendering

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68cc6a2aa0408333970317e6085eb06e