### PR TITLE
Ensure command queue errors trigger retries

### DIFF
--- a/domain-service/src/DomainService.FunctionApp/AssemblyInfo.cs
+++ b/domain-service/src/DomainService.FunctionApp/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DomainService.Tests")]

--- a/domain-service/src/DomainService.FunctionApp/CommandQueueFunction.cs
+++ b/domain-service/src/DomainService.FunctionApp/CommandQueueFunction.cs
@@ -27,6 +27,7 @@ internal sealed class CommandQueueFunction(ISender sender, ILoggerFactory logger
         catch (Exception ex)
         {
             _logger.LogError(ex, "processing command");
+            throw;
         }
     }
 }

--- a/domain-service/tests/DomainService.Tests/CommandQueueFunctionTests.cs
+++ b/domain-service/tests/DomainService.Tests/CommandQueueFunctionTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using DomainService;
+using DomainService.Interfaces;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace DomainService.Tests;
+
+public class CommandQueueFunctionTests
+{
+    [Fact]
+    public async Task Run_Propagates_Exception_From_Command_Handler()
+    {
+        var sender = new ThrowingSender();
+        var commandFactory = new StubCommandFactory();
+        var function = new CommandQueueFunction(sender, NullLoggerFactory.Instance, commandFactory);
+        var context = new Mock<FunctionContext>();
+        context.SetupGet(ctx => ctx.CancellationToken).Returns(CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => function.Run("{}", context.Object));
+    }
+
+    private sealed class ThrowingSender : ISender
+    {
+        Task ISender.Send<TRequest>(TRequest request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Command handler failed.");
+
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Command handler failed.");
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Command handler failed.");
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Command handler failed.");
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Command handler failed.");
+    }
+
+    private sealed class StubCommandFactory : ICommandFactory
+    {
+        public ICommand Create(string queueMessage) => new FakeCommand();
+
+        private sealed record FakeCommand() : ICommand<Unit>;
+    }
+}

--- a/domain-service/tests/DomainService.Tests/DomainService.Tests.csproj
+++ b/domain-service/tests/DomainService.Tests/DomainService.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -25,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\DomainService.FunctionApp\DomainService.FunctionApp.csproj" />
     <ProjectReference Include="..\..\src\DomainService.Domain\DomainService.Domain.csproj" />
     <ProjectReference Include="..\..\src\DomainService.Interfaces\DomainService.Interfaces.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- rethrow queue command exceptions after logging so Azure Storage queue retries and poison handling can run
- expose the function app internals to the test assembly and add a unit test that verifies the function propagates handler failures
- reference the function app project from the test project, add Moq for mocking FunctionContext, and confirmed existing host.json retry/backoff settings remain sensible

## Testing
- dotnet test prism-plan/domain-service/DomainService.sln

------
https://chatgpt.com/codex/tasks/task_e_68cd97303a0c83339f4ae201744add2c