### PR TITLE
Fix integration script for Git Bash

### DIFF
--- a/tests/scripts/run-integration.sh
+++ b/tests/scripts/run-integration.sh
@@ -3,18 +3,41 @@ set -euo pipefail
 ROOT_DIR=$(dirname "$0")/..
 cd "$ROOT_DIR"/..
 
+REPO_ROOT=$(pwd)
+ENV_FILE="$REPO_ROOT/tests/docker/env.test"
 
-ENV_FILE=tests/docker/env.test
+if [[ -n "${MSYSTEM:-}" ]]; then
+  excludes="API_HEALTH_ENDPOINT;AZ_FUNC_HEALTH_ENDPOINT"
+  if [[ -n "${MSYS2_ENV_CONV_EXCL:-}" ]]; then
+    export MSYS2_ENV_CONV_EXCL="${MSYS2_ENV_CONV_EXCL};${excludes}"
+  else
+    export MSYS2_ENV_CONV_EXCL="$excludes"
+  fi
+fi
+
 set -a
 # shellcheck source=tests/docker/env.test
 source "$ENV_FILE"
 set +a
-COMPOSE="docker compose --env-file $ENV_FILE -f docker-compose.yml -f tests/docker/docker-compose.tests.yml"
-$COMPOSE up -d
-trap "$COMPOSE down -v" EXIT
+
+COMPOSE=(
+  docker compose
+  --env-file "$ENV_FILE"
+  -f "$REPO_ROOT/docker-compose.yml"
+  -f "$REPO_ROOT/tests/docker/docker-compose.tests.yml"
+)
+
+cleanup() {
+  "${COMPOSE[@]}" down -v
+}
+trap cleanup EXIT
+
+"${COMPOSE[@]}" up -d
 
 tests/docker/wait-for.sh "${PRISM_API_LB_BASE}${AZ_FUNC_HEALTH_ENDPOINT}" 30
 tests/docker/wait-for.sh "${STREAM_SERVICE_BASE}${API_HEALTH_ENDPOINT}" 30
 
-cd tests/integration && go test ./...
+pushd tests/integration > /dev/null
+go test ./...
+popd > /dev/null
 


### PR DESCRIPTION
## Summary
- prevent MSYS2 path conversion from rewriting health endpoint environment variables when running through Git Bash
- use absolute paths for the docker compose env file and ensure cleanup runs from the repository root
- run Go integration tests from a pushd/popd block so the compose teardown succeeds

## Testing
- `tests/scripts/run-integration.sh` *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3aadbe4788333a8338aab1ebf68d8